### PR TITLE
Skip committed dotenv templates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "secret-guard-scan"
-version = "0.1.1.post1"
+version = "0.1.1.post2"
 description = "Scan your codebase for hardcoded secrets before they get committed."
 readme = "README.md"
 requires-python = ">=3.8"

--- a/secretguard/__init__.py
+++ b/secretguard/__init__.py
@@ -1,3 +1,3 @@
 """secret-guard: scan your codebase for leaked secrets."""
 
-__version__ = "0.1.1.post1"
+__version__ = "0.1.1.post2"

--- a/secretguard/rules.py
+++ b/secretguard/rules.py
@@ -156,8 +156,15 @@ SECRET_KEY_PATTERN = re.compile(
 )
 
 
+DOTENV_TEMPLATE_RE = re.compile(
+    r"\.(?:example|sample|template|dist)(?:\.\w+)*$", re.IGNORECASE
+)
+
+
 def is_dotenv_path(rel_path):
     base = rel_path.rsplit("/", 1)[-1]
+    if DOTENV_TEMPLATE_RE.search(base) and re.search(r"\.env", base, re.IGNORECASE):
+        return False
     return bool(re.search(r"\.env(\.|$)", base, re.IGNORECASE))
 
 

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -197,6 +197,21 @@ class DotenvKeyTest(unittest.TestCase):
         self.assertFalse(is_dotenv_path("environment.py"))
         self.assertFalse(is_dotenv_path("docs/env.md"))
 
+    def test_is_dotenv_path_excludes_committed_templates(self):
+        templates = [
+            ".env.example",
+            ".env.sample",
+            ".env.template",
+            ".env.dist",
+            ".env.local.example",
+            "config/.env.production.example",
+            "prod.ENV.example",
+        ]
+        for path in templates:
+            self.assertFalse(
+                is_dotenv_path(path), f"{path!r} should not be treated as a dotenv file"
+            )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
`.env.example` / `.env.sample` / `.env.template` / `.env.dist` files are intentionally committed so users can copy them into a real `.env` — reporting their keys as secrets is a false positive.

Changes:
- `is_dotenv_path` now returns False for dotenv template files
- covers `.env.example`, `.env.local.example`, `prod.ENV.example`, etc.
- adds tests; bumps to 0.1.1.post2
