### PR TITLE
Add SEO docs site (mkdocs + GitHub Pages)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,31 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: docs
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install mkdocs
+        run: pip install mkdocs-material mkdocs-minify-plugin
+      - name: Build site
+        run: mkdocs build --strict
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,40 @@
+# CI Integration
+
+Use the exit code to fail a pipeline the moment a secret appears.
+
+## GitHub Actions
+
+```yaml
+- name: Scan for secrets
+  run: |
+    pip install secret-guard-scan
+    secret-guard scan . --json --exclude tests --exclude .venv
+```
+
+## Git pre-commit hook
+
+```bash
+secret-guard install-hook
+```
+
+Or use the pre-commit framework. The repository also publishes a
+`pre-commit-hooks.yaml` for use directly:
+
+```yaml
+repos:
+  - repo: https://github.com/taksh1507/secret-guard
+    rev: v0.1.1.post2
+    hooks:
+      - id: secret-guard
+```
+
+## Continuous protection
+
+Apply separate scans for:
+
+- **Working tree** — dev machines (`secret-guard scan`).
+- **Staged files** — just before commit (`secret-guard install-hook`).
+- **PRs** — CI on pull requests (`secret-guard scan . --json`).
+
+Rotation tip: when a finding is real, rotate the key first, then remove it from
+the codebase and commit the fix.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,50 @@
+# CLI Reference
+
+## Global
+
+```
+secret-guard --version
+secret-guard --help
+```
+
+## Commands
+
+### `scan`
+
+```
+secret-guard scan [path] [options]
+```
+
+| Option | Description |
+| --- | --- |
+| `path` | Path to scan (default: `.`) |
+| `--exclude DIR` | Skip additional directory names (repeatable) |
+| `--no-entropy` | Disable high-entropy string detection |
+| `--json` | Output findings as JSON |
+| `--show-value` | Print full secret values (default masks them) |
+| `--staged` | Scan only files staged in git |
+
+### `install-hook`
+
+```
+secret-guard install-hook
+```
+
+Installs a git pre-commit hook so every future commit runs a scan.
+
+## Flags in detail
+
+### `--staged`
+
+Reads each staged file from the **git index** (`git show :<path>`) rather than
+the working tree. This catches secrets that were staged and then deleted before
+commit — exactly what would otherwise be committed.
+
+### `--json`
+
+Emits stable JSON. `--show-value` controls whether masked or raw values appear.
+
+### `--exclude`
+
+Directory names to skip, in addition to the built-in defaults
+(`node_modules`, `venv`, `dist`, `build`, `__pycache__`, and more).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,51 @@
+# Contributing
+
+Contributions of any size are welcome — new detection rules, false-positive
+reports, docs, editor integrations.
+
+## Getting started
+
+```bash
+git clone https://github.com/taksh1507/secret-guard.git
+cd secret-guard
+python -m unittest discover -s tests
+python -m ruff check secretguard tests
+python -m secretguard scan . --exclude tests --no-entropy
+```
+
+## Where things live
+
+| File | Purpose |
+| --- | --- |
+| `secretguard/rules.py` | Detection rules, entropy heuristics, `.env` logic |
+| `secretguard/scanner.py` | Filesystem walk, gitignore filtering, scanning |
+| `secretguard/reporter.py` | Console and JSON output (masking) |
+| `secretguard/cli.py` | Argument parsing and commands |
+| `tests/` | Unit tests (unittest) |
+
+## Adding a rule
+
+1. Add an entry to `RULES` in `secretguard/rules.py` using the `_r` helper.
+2. Add a test in `tests/test_rules.py` using a synthetic fixture (never a real
+   leaked secret).
+3. Run `python -m unittest discover -s tests` and `ruff check secretguard tests`.
+
+## Definition of done
+
+- `python -m unittest discover -s tests` passes
+- `python -m ruff check secretguard tests` is clean
+- `python -m secretguard scan . --exclude tests --no-entropy` reports
+  `0 critical, 0 high, 0 medium, 0 low`
+- No raw secret values are added to tests, fixtures, or docs
+
+## Good first issues
+
+Filter the issue tracker:
+https://github.com/taksh1507/secret-guard/issues?q=label%3A%22good+first+issue%22
+
+## Recognition
+
+Every merged PR is credited in release notes. Please read our
+[Code of Conduct](https://github.com/taksh1507/secret-guard/blob/main/CODE_OF_CONDUCT.md)
+and report security issues per our
+[Security Policy](https://github.com/taksh1507/secret-guard/blob/main/SECURITY.md).

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,55 @@
+# FAQ
+
+## What does secret-guard scan for?
+
+API keys (AWS, Google, Stripe), tokens (GitHub, Slack, Square), JWTs, private
+keys, credential assignments, `.env` secrets, and high-entropy strings.
+
+## Is secret-guard really zero-dependency?
+
+Yes. The core scanner uses only the Python standard library. It shells out to
+`git` for `--staged` scanning, and to nothing else.
+
+## Does it send my code anywhere?
+
+No. Scanning is 100% local. There are no network calls.
+
+## Why are secret values masked by default?
+
+Because a scanner that prints your API key is part of the problem. Values are
+redacted unless you pass `--show-value` (useful for rotating the key).
+
+## Why does my `.env.example` show no findings?
+
+`.env.example`, `.env.sample`, `.env.template`, and `.env.dist` are
+commit-intended templates. secret-guard skips them so you can document your
+environment without tripping scans. A real `.env` file with secret keys **is**
+still detected.
+
+## Why do I see thousands of LOW findings in package-lock.json?
+
+Those are npm `sha512` hashes with high entropy. They are not secrets. Run with
+`--no-entropy` to suppress entropy-only findings, or let the baseline feature
+(planned) handle them.
+
+## How do I keep scans fast?
+
+Exclude generated folders (`node_modules`, `.next`, `data`, `models`) and use
+`--no-entropy` when you only care about pattern matches.
+
+## Does it support pre-commit?
+
+Yes — `secret-guard install-hook` installs a git hook, and the repository ships
+a `pre-commit-hooks.yaml` for the pre-commit framework.
+
+## Is there a GitHub Action?
+
+Coming soon (issue
+[#10](https://github.com/taksh1507/secret-guard/issues/10)).
+
+## How is this different from gitleaks or trufflehog?
+
+secret-guard is a lightweight, zero-dependency Python package that runs locally,
+has a tiny install footprint, works in CI with one line, and masks secrets by
+default. It is designed to be installed and forgot — not an agent that needs
+config, Docker, or a platform account.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,53 @@
+# secret-guard
+
+**Open-source secret scanner for Python, CI, and pre-commit hooks.**
+
+Detect leaked API keys, AWS keys, GitHub tokens, Slack tokens, passwords, JWTs,
+and private keys **before** they reach your git history.
+
+- Zero runtime dependencies
+- 13 detection rules + Shannon-entropy heuristics
+- `.env` support (.env, .env.*, *.env, *.env.*) and committed template files
+  (.env.example) are skipped by design
+- Git-index-aware `--staged` scanning
+- Secret values are **masked by default** in console and JSON output
+- One-line install: `pip install secret-guard-scan`
+
+## How it works
+
+`secret-guard` walks a directory (respecting `.gitignore`), runs every rule
+against each file, and reports findings with a severity and a **masked** value.
+It never sends anything to a network — everything runs locally, in pure Python.
+
+## Quick start
+
+```bash
+pip install secret-guard-scan
+secret-guard scan .          # scan the current directory
+secret-guard scan --json     # JSON output for CI
+secret-guard scan --staged   # scan only files staged in git
+secret-guard install-hook    # protect every future commit
+```
+
+## Why secret-guard?
+
+- **No external services, no Docker, no config file** — one pip package.
+- **Masked by default** — a scanner that prints your API key is part of the
+  problem. `--show-value` is an explicit opt-in.
+- **Catches staged-and-deleted secrets** by reading the git index blob, not the
+  working tree.
+- **False-positive friendly** — committed `.env.example` templates are ignored;
+  entropy findings are reported as `low` severity by default.
+
+## Resources
+
+- [Getting Started](usage.md)
+- [CLI Reference](cli.md)
+- [Detection Rules](rules.md)
+- [CI Integration](ci.md)
+- [Contributing](contributing.md)
+- [FAQ](faq.md)
+
+## License
+
+[MIT](https://github.com/taksh1507/secret-guard/blob/main/LICENSE)

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://taksh1507.github.io/secret-guard/sitemap.xml

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1,0 +1,33 @@
+# Detection Rules
+
+secret-guard ships with 13 pattern rules plus entropy heuristics.
+
+| Category | Rules |
+| --- | --- |
+| Cloud / SaaS | AWS Access Key IDs, AWS temporary & dashed keys, Google API Keys, Stripe live keys |
+| Tokens | GitHub PAT (classic & fine-grained), Slack tokens, Square access tokens, JWTs |
+| Key material | RSA / EC / DSA / OpenSSH / PGP private keys (`CRITICAL`) |
+| Heuristics | Generic secret keys, credential assignments, high-entropy strings |
+
+## `.env` files
+
+`.env`, `.env.*`, `*.env`, and `*.env.*` files are special-cased: secret-looking
+keys are reported **by name only**, and the value is never echoed.
+
+Committed **template files** — `.env.example`, `.env.sample`, `.env.template`,
+`.env.dist`, and their variants — are ignored entirely. These files are meant to
+be committed so users can copy them into a real `.env`; flagging them would be a
+false positive.
+
+## Entropy detection
+
+Strings of 20+ alphanumeric characters with Shannon entropy >= 3.5 bits/char are
+flagged as `low` severity. Use `--no-entropy` to disable:
+the npm `sha512` hashes in `package-lock.json` are common `low` findings.
+
+## Severity levels
+
+- `critical` — private key material
+- `high` — provider API keys, tokens
+- `medium` — generic secret keys, credential assignments
+- `low` — high-entropy strings

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,65 @@
+# Getting Started
+
+## Installation
+
+```bash
+pip install secret-guard-scan
+```
+
+The CLI is `secret-guard`. You can also run the repository directly without
+installing (Python >= 3.8):
+
+```bash
+python -m secretguard
+```
+
+## First scan
+
+```bash
+cd your-repo
+secret-guard scan
+```
+
+This scans the current directory, skips gitignored paths, and prints any
+findings with severity and a masked value:
+
+```
+config.py:12 [HIGH    ] GitHub Token: ghp_**************
+.env:4    [CRITICAL] Private Key: -----BEGIN [REDACTED]-----
+app.py:40 [MEDIUM  ] Credential Assignment: password = 'hunter 2'
+
+1 critical, 1 high, 1 medium, 0 low — 3 total
+```
+
+## Skipping heavy or generated directories
+
+Large folders such as `node_modules`, `.venv`, build caches, and ML artifacts
+should be excluded to keep scans fast:
+
+```bash
+secret-guard scan . \
+  --exclude node_modules \
+  --exclude data \
+  --exclude models \
+  --exclude reports \
+  --exclude .next \
+  --exclude __pycache__
+```
+
+`node_modules`, `venv`, `dist`, `build`, `__pycache__` and similar are skipped
+by default.
+
+## Example output in JSON
+
+```bash
+secret-guard scan . --json
+```
+
+Values are masked in JSON too unless `--show-value` is passed.
+
+## Exit codes
+
+- `0` — no secrets found
+- `1` — at least one secret detected
+
+Use the exit code to gate CI builds.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,52 @@
+site_name: secret-guard
+site_description: "secret-guard — open-source, zero-dependency Python secret scanner. Detect leaked API keys, AWS keys, GitHub tokens, passwords, and private keys before they reach git history. A gitleaks/trufflehog alternative for CI and pre-commit."
+site_author: secret-guard contributors
+site_url: https://taksh1507.github.io/secret-guard/
+repo_url: https://github.com/taksh1507/secret-guard
+repo_name: taksh1507/secret-guard
+docs_dir: docs
+site_dir: site
+edit_uri: edit/main/docs/
+use_directory_urls: true
+
+theme:
+  name: material
+  palette:
+    - scheme: slate
+      primary: indigo
+      accent: indigo
+  features:
+    - navigation.top
+    - navigation.sections
+    - search.highlight
+    - toc.follow
+
+nav:
+  - Home: index.md
+  - Getting Started: usage.md
+  - CLI Reference: cli.md
+  - Detection Rules: rules.md
+  - CI Integration: ci.md
+  - Contributing: contributing.md
+  - FAQ: faq.md
+
+markdown_extensions:
+  - admonition
+  - toc:
+      permalink: true
+  - pymdownx.superfences
+  - pymdownx.tasklist
+
+plugins:
+  - search
+  - tags
+  - minify:
+      minify_html: true
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/taksh1507/secret-guard
+    - icon: fontawesome/brands/python
+      link: https://pypi.org/project/secret-guard-scan/
+  generator: false


### PR DESCRIPTION
SEO documentation site for secret-guard:

- mkdocs + material theme site at https://taksh1507.github.io/secret-guard/
- `site_description` and `site_url` for search engines
- Auto-generated `sitemap.xml` + `robots.txt`
- FAQ page with question headings (rich-snippet friendly), rules page, CLI/CI/contributing pages
- Cross-linked keywords: "python secret scanner", "gitleaks/trufflehog alternative", "find leaked API keys"
- Deploys on push to main via a new Docs workflow