### PR TITLE
feat: add detection rules for npm, SendGrid, Twilio, Heroku, DigitalOcean, and HubSpot

### DIFF
--- a/secretguard/rules.py
+++ b/secretguard/rules.py
@@ -83,7 +83,8 @@ RULES = [
         description="Twilio API key SID.",
     ),
     _r(
-        r"(?i)heroku[a-z0-9_.\-\t ]{0,30}(?:=|>|:=|\|\|:|<=|=>|:|\s)\s*['\"]?([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})['\"]?",
+        r"(?i)heroku[a-z0-9_.\-\t ]{0,30}(?:=|>|:=|\|\|:|<=|=>|:|\s)\s*"
+        r"['\"]?([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})['\"]?",
         "Heroku API Key",
         severity="high",
         description="Heroku API key or authorization token.",

--- a/secretguard/rules.py
+++ b/secretguard/rules.py
@@ -65,6 +65,42 @@ RULES = [
         description="Stripe live secret API key.",
     ),
     _r(
+        r"npm_[a-z0-9]{36}",
+        "npm Token",
+        severity="high",
+        description="npm registry access token.",
+    ),
+    _r(
+        r"SG\.[a-z0-9_-]{22}\.[a-z0-9_-]{43}",
+        "SendGrid API Key",
+        severity="high",
+        description="SendGrid API key.",
+    ),
+    _r(
+        r"SK[a-f0-9]{32}",
+        "Twilio API Key",
+        severity="high",
+        description="Twilio API key SID.",
+    ),
+    _r(
+        r"(?i)heroku[a-z0-9_.\-\t ]{0,30}(?:=|>|:=|\|\|:|<=|=>|:|\s)\s*['\"]?([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})['\"]?",
+        "Heroku API Key",
+        severity="high",
+        description="Heroku API key or authorization token.",
+    ),
+    _r(
+        r"do[oprt]_v1_[a-f0-9]{64}",
+        "DigitalOcean Token",
+        severity="high",
+        description="DigitalOcean personal access or OAuth token.",
+    ),
+    _r(
+        r"pat-[a-z0-9-]{32,}",
+        "HubSpot Access Token",
+        severity="high",
+        description="HubSpot Private App Access Token.",
+    ),
+    _r(
         r"sk-[0-9a-fA-F]{32,}",
         "Generic Secret Key",
         severity="medium",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 """End-to-end tests for the secret-guard command line."""
 
+import os
 import shutil
 import subprocess
 import sys
@@ -19,7 +20,6 @@ def run_git(repo, *args):
 
 class CliTest(unittest.TestCase):
     def run_cli(self, cwd, *args):
-        import os
         env = os.environ.copy()
         env["PYTHONPATH"] = str(PROJECT_ROOT)
         return subprocess.run(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,11 +19,15 @@ def run_git(repo, *args):
 
 class CliTest(unittest.TestCase):
     def run_cli(self, cwd, *args):
+        import os
+        env = os.environ.copy()
+        env["PYTHONPATH"] = str(PROJECT_ROOT)
         return subprocess.run(
             [sys.executable, "-m", "secretguard", *args],
             capture_output=True,
             text=True,
             cwd=cwd,
+            env=env,
             check=False,
         )
 

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -88,6 +88,54 @@ class RuleDetectionTest(unittest.TestCase):
             rule_names("sk-live-1234567890abcdefghijklmnopqrstuvwxyz"),
         )
 
+    def test_npm_token(self):
+        self.assertIn(
+            "npm Token",
+            rule_names("token = npm_" + "a" * 36),
+        )
+
+    def test_sendgrid_api_key(self):
+        self.assertIn(
+            "SendGrid API Key",
+            rule_names("key = SG." + "a" * 22 + "." + "b" * 43),
+        )
+
+    def test_twilio_api_key(self):
+        self.assertIn(
+            "Twilio API Key",
+            rule_names("api_key = SK" + "a" * 32),
+        )
+
+    def test_heroku_api_key(self):
+        self.assertIn(
+            "Heroku API Key",
+            rule_names("heroku_api_key = '00000000-0000-0000-0000-000000000000'"),
+        )
+        self.assertIn(
+            "Heroku API Key",
+            rule_names("heroku publish token 00000000-0000-0000-0000-000000000000"),
+        )
+
+    def test_digitalocean_token(self):
+        self.assertIn(
+            "DigitalOcean Token",
+            rule_names("token = dop_v1_" + "a" * 64),
+        )
+        self.assertIn(
+            "DigitalOcean Token",
+            rule_names("token = doo_v1_" + "a" * 64),
+        )
+
+    def test_hubspot_access_token(self):
+        self.assertIn(
+            "HubSpot Access Token",
+            rule_names("token = pat-na1-" + "a" * 32),
+        )
+        self.assertIn(
+            "HubSpot Access Token",
+            rule_names("token = pat-eu1-" + "a" * 32),
+        )
+
     def test_generic_secret_key(self):
         self.assertIn(
             "Generic Secret Key",


### PR DESCRIPTION
This PR resolves #12 by implementing detection rules for: - npm tokens - SendGrid API keys - Twilio API keys - Heroku API keys - DigitalOcean personal access / OAuth tokens - HubSpot access tokens. It also updates tests to ensure PYTHONPATH is set when testing the CLI in subprocesses.