### PR TITLE
Colored output + stable JSON schema

### DIFF
--- a/secretguard/cli.py
+++ b/secretguard/cli.py
@@ -60,6 +60,10 @@ def build_parser():
         help="Print full secret values (default masks them).",
     )
     scan.add_argument(
+        "--no-color", action="store_true",
+        help="Disable colored console output.",
+    )
+    scan.add_argument(
         "--staged", action="store_true",
         help="Scan only files staged in git.",
     )
@@ -131,7 +135,12 @@ def cmd_scan(args):
             )
         )
     else:
-        print(format_console(findings, args.path, show_value=args.show_value))
+        color = False if args.no_color else None
+        print(
+            format_console(
+                findings, args.path, show_value=args.show_value, color=color
+            )
+        )
     return 1 if findings else 0
 
 

--- a/secretguard/reporter.py
+++ b/secretguard/reporter.py
@@ -13,7 +13,13 @@ SEVERITY_COLORS = {
 RESET = "\033[0m"
 
 
-def should_color():
+SCHEMA_VERSION = 1
+
+
+def should_color(force=None):
+    """force=True/False overrides auto-detection; None means auto (TTY + NO_COLOR)."""
+    if force is not None:
+        return force
     return sys.stdout.isatty() and os.environ.get("NO_COLOR") is None
 
 
@@ -22,9 +28,8 @@ def mask(value, visible=6):
         return "*" * len(value)
     return value[:visible] + "*" * max(0, len(value) - visible - 0)
 
-
-def format_console(findings, root, show_value=True):
-    color = should_color()
+def format_console(findings, root, show_value=True, color=None):
+    color = should_color(force=color)
     lines = []
     for finding in sorted(findings, key=lambda f: (f["path"], f["line"])):
         severity = finding["severity"]
@@ -79,10 +84,14 @@ def summarize(findings):
 
 
 def format_json(findings, root, show_value=False):
+    ordered = sorted(findings, key=lambda f: (f["path"], f["line"], f["rule"]))
     sanitized = []
-    for finding in findings:
+    for finding in ordered:
         item = dict(finding)
         if not show_value and not finding.get("reveal"):
             item["value"] = mask(item["value"])
         sanitized.append(item)
-    return json.dumps({"root": root, "findings": sanitized}, indent=2)
+    return json.dumps(
+        {"schema_version": SCHEMA_VERSION, "root": root, "findings": sanitized},
+        indent=2,
+    )

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -135,6 +135,51 @@ class FormatJsonTest(unittest.TestCase):
         report = format_json([], ".")
         self.assertIsNotNone(re.match(r"^\s*\{.*\}\s*$", report, re.DOTALL))
 
+class ColorTest(unittest.TestCase):
+    def test_forced_color_true_colors_output(self):
+        value = "ghp_" + "a" * 34
+        report = format_console(
+            [finding(value=value)], ".", show_value=True, color=True
+        )
+        self.assertIn("\033[", report)
+
+    def test_forced_color_false_is_plain(self):
+        value = "ghp_" + "a" * 34
+        report = format_console(
+            [finding(value=value)], ".", show_value=True, color=False
+        )
+        self.assertNotIn("\033[", report)
+
+    def test_default_auto_detect_is_plain_when_not_a_tty(self):
+        value = "ghp_" + "a" * 34
+        report = format_console([finding(value=value)], ".", show_value=True)
+        self.assertNotIn("\033[", report)
+
+
+class JsonSchemaTest(unittest.TestCase):
+    def test_schema_version_present(self):
+        payload = json.loads(format_json([], "."))
+        self.assertEqual(payload["schema_version"], 1)
+
+    def test_findings_sorted_by_path_line_rule(self):
+        findings = [
+            finding(path="b.py", line=2, rule="Z Rule"),
+            finding(path="a.py", line=9, rule="A Rule"),
+            finding(path="a.py", line=1, rule="B Rule"),
+        ]
+        payload = json.loads(format_json(findings, "."))
+        paths_lines = [(f["path"], f["line"]) for f in payload["findings"]]
+        self.assertEqual(paths_lines, [("a.py", 1), ("a.py", 9), ("b.py", 2)])
+
+    def test_ordering_is_deterministic_across_runs(self):
+        findings = [
+            finding(path="b.py", line=2),
+            finding(path="a.py", line=1),
+        ]
+        first = format_json(list(findings), ".")
+        second = format_json(list(reversed(findings)), ".")
+        self.assertEqual(first, second)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -281,5 +281,7 @@ class DotenvValueParsingTest(unittest.TestCase):
 
 
 
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What this changes

- Console output is now colorized by severity when stdout is a TTY, plain when piped. `--no-color` flag and `NO_COLOR` env var both force plain output. Fixes #15.
- JSON output now includes a `schema_version` field and sorts findings deterministically by `(path, line, rule)`.
- Masking guarantee is unchanged: colored or JSON, values stay masked unless `--show-value`.

## Testing

Added `ColorTest` (forced color on/off, auto-detect plain when not a TTY) and `JsonSchemaTest` (schema_version presence, sort order, deterministic output across differently-ordered input) in `tests/test_reporter.py`.

Note: `tests/test_cli.py` has 8 pre-existing failures unrelated to this change (same failures present without my changes, confirmed via `git stash`).