### PR TITLE
chore: bump version to 0.1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "secret-guard-scan"
-version = "0.1.1.post2"
+version = "0.1.2"
 description = "Scan your codebase for hardcoded secrets before they get committed."
 readme = "README.md"
 requires-python = ">=3.8"

--- a/secretguard/__init__.py
+++ b/secretguard/__init__.py
@@ -1,3 +1,3 @@
 """secret-guard: scan your codebase for leaked secrets."""
 
-__version__ = "0.1.1.post2"
+__version__ = "0.1.2"


### PR DESCRIPTION
Bump version from 0.1.1.post2 to 0.1.2 ahead of the 0.1.2 release (new detection rules, colored output, robust .env parsing). When merged, tag v0.1.2 will trigger the PyPI publish workflow.