### PR TITLE
fix: keep release-please tags in v0.x.x format

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -16,6 +16,7 @@
   "packages": {
     ".": {
       "package-name": "secret-guard-scan",
+      "include-component-in-tag": false,
       "extra-files": [
         {
           "type": "generic",


### PR DESCRIPTION
Ensures release-please creates v0.x.x tags so publish.yml triggers.