### PR TITLE
ci: use RELEASE_PLEASE_PAT token to avoid bot-PR approval gate

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,6 +14,6 @@ jobs:
     steps:
       - uses: google-github-actions/release-please-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_PAT || github.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
GitHub now holds workflow runs on PRs authored by github-actions[bot] in action_required. Passing a real-user PAT to release-please-action attributes its pushes/PRs to that user so CI/scan checks run normally. Falls back to github.token if RELEASE_PLEASE_PAT is unset.