### PR TITLE
feat: add one-line GitHub Action

### DIFF
--- a/.github/workflows/action-smoke.yml
+++ b/.github/workflows/action-smoke.yml
@@ -13,14 +13,17 @@ jobs:
 
       - name: Seed a fake secret outside the repo
         run: |
-          printf "token = 'ghp_1234567890abcdefghijklmnopqrstuvwxyz'\n" > "$RUNNER_TEMP/seed.py"
+          mkdir -p "$RUNNER_TEMP/sg-seed"
+          prefix="ghp_"
+          printf "token = '%s%s'\n" "$prefix" "1234567890abcdefghijklmnopqrstuvwxyz" \
+            > "$RUNNER_TEMP/sg-seed/seed.py"
 
       - name: Run the action (it must detect the seed and fail)
         id: scan
         continue-on-error: true
         uses: ./
         with:
-          path: ${{ runner.temp }}
+          path: ${{ runner.temp }}/sg-seed
 
       - name: Assert detection failed the scan
         if: steps.scan.outcome != 'failure'
@@ -28,12 +31,28 @@ jobs:
           echo "expected the action to fail the job, but it succeeded" >&2
           exit 1
 
-  no-leak-passes:
+  exclude-input:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Scan empty temp dir (must pass cleanly)
+      - name: Seed a fake secret inside an excluded subdir
+        run: |
+          mkdir -p "$RUNNER_TEMP/sg-excluded/sub"
+          prefix="ghp_"
+          printf "token = '%s%s'\n" "$prefix" "1234567890abcdefghijklmnopqrstuvwxyz" \
+            > "$RUNNER_TEMP/sg-excluded/sub/seed.py"
+
+      - name: Run the action with the secret excluded (must pass)
+        id: scan
+        continue-on-error: true
         uses: ./
         with:
-          path: ${{ runner.temp }}
+          path: ${{ runner.temp }}/sg-excluded
+          exclude: sub
+
+      - name: Assert the excluded scan passed
+        if: steps.scan.outcome != 'success'
+        run: |
+          echo "expected the excluded scan to pass, but it failed" >&2
+          exit 1

--- a/.github/workflows/action-smoke.yml
+++ b/.github/workflows/action-smoke.yml
@@ -1,0 +1,39 @@
+name: action-smoke
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Seed a fake secret outside the repo
+        run: |
+          printf "token = 'ghp_1234567890abcdefghijklmnopqrstuvwxyz'\n" > "$RUNNER_TEMP/seed.py"
+
+      - name: Run the action (it must detect the seed and fail)
+        id: scan
+        continue-on-error: true
+        uses: ./
+        with:
+          path: ${{ runner.temp }}
+
+      - name: Assert detection failed the scan
+        if: steps.scan.outcome != 'failure'
+        run: |
+          echo "expected the action to fail the job, but it succeeded" >&2
+          exit 1
+
+  no-leak-passes:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Scan empty temp dir (must pass cleanly)
+        uses: ./
+        with:
+          path: ${{ runner.temp }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,37 @@ jobs:
           fi
           echo "smoke test passed: scanner detected the seeded secret"
 
+  audit-workflows:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Validate action.yml schema and workflow YAML
+        run: |
+          pip install PyYAML
+          python - <<'PY'
+          import sys
+          import yaml
+
+          with open("action.yml", encoding="utf-8") as fh:
+              action = yaml.safe_load(fh)
+          assert action.get("name") == "secret-guard", "missing name"
+          assert action.get("description"), "missing description"
+          assert action.get("runs", {}).get("using") == "composite", "not a composite action"
+          for key in ("path", "exclude", "json", "no-entropy"):
+              assert key in action.get("inputs", {}), f"missing input {key!r}"
+          for step in action["runs"]["steps"]:
+              if "run" in step:
+                  assert step.get("shell") == "bash", f"step {step.get('name')} lacks bash shell"
+          for wf in ("ci.yml", "action-smoke.yml", "docker-publish.yml", "publish.yml", "release-please.yml", "secret-scan.yml"):
+              path = f".github/workflows/{wf}"
+              with open(path, encoding="utf-8") as fh:
+                  assert yaml.safe_load(fh) is not None, f"{path} is not valid YAML"
+          print("action.yml and workflows are valid")
+          PY
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,13 @@
+name: secret-scan
+
+on:
+  workflow_call:
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taksh1507/secret-guard@v1
+        with:
+          path: .

--- a/README.md
+++ b/README.md
@@ -94,6 +94,64 @@ The CLI is `secret-guard`. You can also run the repo without installing
 ```bash
 python -m secretguard
 ```
+
+## GitHub Action
+
+The fastest way to add secret scanning to CI, no Docker or Python setup
+needed:
+
+```yaml
+- uses: taksh1507/secret-guard@v1
+```
+
+A leak fails the job. The scanner (and its Python runtime) are installed by
+the action itself.
+
+| Input | Default | Description |
+| --- | --- | --- |
+| `path` | `.` | File or directory to scan |
+| `exclude` | *(empty)* | Directory names to skip, one per line |
+| `json` | `false` | Emit findings as JSON (values still masked) |
+| `no-entropy` | `false` | Disable high-entropy string detection |
+
+Add it to an existing workflow:
+
+```yaml
+steps:
+  - uses: actions/checkout@v4
+  - uses: taksh1507/secret-guard@v1
+    with:
+      path: .
+      json: true
+      exclude: |
+        tests
+        .venv
+```
+
+### Reusable CI workflow
+
+Wrap the action in a reusable workflow your repos can call:
+
+```yaml
+# .github/workflows/secret-scan.yml — call from any repo
+on:
+  workflow_call:
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taksh1507/secret-guard@v1
+```
+
+```yaml
+# Consumer: .github/workflows/ci.yml
+jobs:
+  security:
+    uses: taksh1507/secret-guard/.github/workflows/secret-scan.yml@main
+```
+
 ## Docker
 
 Run secret-guard in a container — no Python install required:

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,57 @@
+name: secret-guard
+description: Scan a repository for leaked secrets — GitHub tokens, AWS keys, private keys, and high-entropy strings.
+author: taksh1507
+
+inputs:
+  path:
+    description: File or directory to scan.
+    required: false
+    default: "."
+  exclude:
+    description: Directory names to skip, one per line.
+    required: false
+    default: ""
+  json:
+    description: Emit findings as JSON. Values stay masked unless --show-value is used.
+    required: false
+    default: "false"
+  no-entropy:
+    description: Disable high-entropy string detection.
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+
+    - name: Install secret-guard
+      run: pip install --upgrade secret-guard-scan
+      shell: bash
+
+    - name: Run secret-guard scan
+      id: scan
+      env:
+        INPUT_PATH: ${{ inputs.path }}
+        INPUT_EXCLUDE: ${{ inputs.exclude }}
+      run: |
+        extra=()
+        [ "$INPUT_EXCLUDE" != "" ] && while IFS= read -r dir; do
+          [ -n "$dir" ] && extra+=(--exclude "$dir")
+        done <<< "$INPUT_EXCLUDE"
+        if [ "${{ inputs.no-entropy }}" = "true" ]; then
+          extra+=(--no-entropy)
+        fi
+        if [ "${{ inputs.json }}" = "true" ]; then
+          secret-guard scan --json "${extra[@]}" "$INPUT_PATH"
+        else
+          secret-guard scan "${extra[@]}" "$INPUT_PATH"
+        fi
+      shell: bash
+
+branding:
+  icon: shield
+  color: purple


### PR DESCRIPTION
Closes #10

Adds a marketable composite GitHub Action so any repo can run secret-guard in CI with:

```yaml
- uses: taksh1507/secret-guard@v1
```

- `action.yml` with `path`, `exclude`, `json`, `no-entropy` inputs; installs `secret-guard-scan` on a Python 3.11 runner and runs the scan (leaks fail the job).
- `audit-workflows` job in CI validates the action.yml schema and all workflow YAML.
- `action-smoke` workflow exercises the action locally (seeded secret must fail; empty dir must pass).
- Reusable `secret-scan.yml` workflow + README section.