### PR TITLE
chore: allow manual dispatch of docker-publish

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
release-please creates tags with `GITHUB_TOKEN`, which does not fire tag-triggered workflows (0.2.0/0.3.0 affected). Adds `workflow_dispatch` so admins can publish the Docker image for a tag without waiting for (or in addition to) the tag trigger. Set the RELEASE_PLEASE_PAT repo secret to make tag pushes trigger naturally.