### PR TITLE
fix: point smoke CI and audit at relocated action

### DIFF
--- a/.github/actions/secret-guard/action.yml
+++ b/.github/actions/secret-guard/action.yml
@@ -1,0 +1,57 @@
+name: secret-guard
+description: Scan a repository for leaked secrets — GitHub tokens, AWS keys, private keys, and high-entropy strings.
+author: taksh1507
+
+inputs:
+  path:
+    description: File or directory to scan.
+    required: false
+    default: "."
+  exclude:
+    description: Directory names to skip, one per line.
+    required: false
+    default: ""
+  json:
+    description: Emit findings as JSON. Values stay masked unless --show-value is used.
+    required: false
+    default: "false"
+  no-entropy:
+    description: Disable high-entropy string detection.
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+
+    - name: Install secret-guard
+      run: pip install --upgrade secret-guard-scan
+      shell: bash
+
+    - name: Run secret-guard scan
+      id: scan
+      env:
+        INPUT_PATH: ${{ inputs.path }}
+        INPUT_EXCLUDE: ${{ inputs.exclude }}
+      run: |
+        extra=()
+        [ "$INPUT_EXCLUDE" != "" ] && while IFS= read -r dir; do
+          [ -n "$dir" ] && extra+=(--exclude "$dir")
+        done <<< "$INPUT_EXCLUDE"
+        if [ "${{ inputs.no-entropy }}" = "true" ]; then
+          extra+=(--no-entropy)
+        fi
+        if [ "${{ inputs.json }}" = "true" ]; then
+          secret-guard scan --json "${extra[@]}" "$INPUT_PATH"
+        else
+          secret-guard scan "${extra[@]}" "$INPUT_PATH"
+        fi
+      shell: bash
+
+branding:
+  icon: shield
+  color: purple

--- a/.github/workflows/action-smoke.yml
+++ b/.github/workflows/action-smoke.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Run the action (it must detect the seed and fail)
         id: scan
         continue-on-error: true
-        uses: ./
+        uses: ./.github/actions/secret-guard
         with:
           path: ${{ runner.temp }}/sg-seed
 
@@ -46,7 +46,7 @@ jobs:
       - name: Run the action with the secret excluded (must pass)
         id: scan
         continue-on-error: true
-        uses: ./
+        uses: ./.github/actions/secret-guard
         with:
           path: ${{ runner.temp }}/sg-excluded
           exclude: sub

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,9 @@ jobs:
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.13'
         uses: codecov/codecov-action@v4
-        with:
-          files: coverage.xml
-          fail_ci_if_error: false
+with:
+            files: coverage.xml
+            fail_ci_if_error: false
       - name: Smoke test
         run: |
           cd "$RUNNER_TEMP"
@@ -56,7 +56,7 @@ jobs:
           import sys
           import yaml
 
-          with open("action.yml", encoding="utf-8") as fh:
+          with open(".github/actions/secret-guard/action.yml", encoding="utf-8") as fh:
               action = yaml.safe_load(fh)
           assert action.get("name") == "secret-guard", "missing name"
           assert action.get("description"), "missing description"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,9 @@ jobs:
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.13'
         uses: codecov/codecov-action@v4
-with:
-            files: coverage.xml
-            fail_ci_if_error: false
+        with:
+          files: coverage.xml
+          fail_ci_if_error: false
       - name: Smoke test
         run: |
           cd "$RUNNER_TEMP"


### PR DESCRIPTION
action.yml moved to .github/actions/secret-guard/ in #43. This updates the smoke workflow (`uses: ./.github/actions/secret-guard`) and the audit-workflows schema check path so they test the real action.