### PR TITLE
feat(rules): add OpenAI, Anthropic, and Discord bot token detection

### DIFF
--- a/secretguard/rules.py
+++ b/secretguard/rules.py
@@ -93,6 +93,24 @@ RULES = [
         description="Stripe live secret API key.",
     ),
     _r(
+        r"sk-[a-z0-9]{48}|sk-proj-[a-z0-9_-]{20,}",
+        "OpenAI API Key",
+        severity="high",
+        description="OpenAI API key.",
+    ),
+    _r(
+        r"sk-ant-[a-z0-9_-]{20,}",
+        "Anthropic API Key",
+        severity="high",
+        description="Anthropic API key.",
+    ),
+    _r(
+        r"[a-z0-9_-]{24,28}\.[a-z0-9_-]{6}\.[a-z0-9_-]{27,45}",
+        "Discord Bot Token",
+        severity="high",
+        description="Discord API bot token.",
+    ),
+    _r(
         r"npm_[a-z0-9]{36}",
         "npm Token",
         severity="high",

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -107,7 +107,10 @@ class RuleDetectionTest(unittest.TestCase):
     def test_discord_bot_token(self):
         self.assertIn(
             "Discord Bot Token",
-            rule_names("token = 123456789012345678901234.123456.123456789012345678901234567890"),
+            rule_names(
+                "token = 123456789012345678901234."
+                "123456.123456789012345678901234567890"
+            ),
         )
 
     def test_npm_token(self):

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -88,6 +88,28 @@ class RuleDetectionTest(unittest.TestCase):
             rule_names("sk-live-1234567890abcdefghijklmnopqrstuvwxyz"),
         )
 
+    def test_openai_api_key(self):
+        self.assertIn(
+            "OpenAI API Key",
+            rule_names("key = sk-" + "a" * 48),
+        )
+        self.assertIn(
+            "OpenAI API Key",
+            rule_names("key = sk-proj-" + "a" * 20),
+        )
+
+    def test_anthropic_api_key(self):
+        self.assertIn(
+            "Anthropic API Key",
+            rule_names("key = sk-ant-" + "a" * 20),
+        )
+
+    def test_discord_bot_token(self):
+        self.assertIn(
+            "Discord Bot Token",
+            rule_names("token = 123456789012345678901234.123456.123456789012345678901234567890"),
+        )
+
     def test_npm_token(self):
         self.assertIn(
             "npm Token",


### PR DESCRIPTION
This PR adds detection rules and unit tests for three common API key/token types that were missing from \secret-guard\:

1. **OpenAI API Keys**: Handles both legacy user/org-level keys (\sk-...\) and modern project-based keys (\sk-proj-...\).
2. **Anthropic API Keys**: Handles keys starting with \sk-ant-...\.
3. **Discord Bot Tokens**: Handles bot tokens formatted as \USER_ID.TIMESTAMP.HMAC\.

All rules have accompanying unit tests added to \	ests/test_rules.py\, and the entire test suite passes successfully.