### PR TITLE
Add --stdin support to scan piped input (#53)

### DIFF
--- a/secretguard/cli.py
+++ b/secretguard/cli.py
@@ -164,6 +164,14 @@ def build_parser():
         "--list-rules", action="store_true",
         help="List every available rule id and exit.",
     )
+    scan.add_argument(
+        "--stdin", action="store_true",
+        help="Read content to scan from stdin instead of a path on disk.",
+    )
+    scan.add_argument(
+        "--filename", default="stdin", metavar="NAME",
+        help="Reported path for --stdin input (default: stdin).",
+    )
     scan.set_defaults(func=cmd_scan)
 
     hooks = subparsers.add_parser(
@@ -302,7 +310,17 @@ def cmd_scan(args):
 
     baseline = resolve_baseline(args, config)
 
-    if args.staged:
+    if args.stdin:
+        scanner = Scanner(
+            ".",
+            excludes=exclude,
+            skip_rules=skip_rules,
+            only_rules=only_rules,
+        )
+        scanner.include_entropy = not no_entropy
+        text = sys.stdin.read()
+        findings = scanner.scan_text(args.filename, text)
+    elif args.staged:
         files = staged_files()
         scanner = Scanner(
             ".",

--- a/secretguard/cli.py
+++ b/secretguard/cli.py
@@ -274,6 +274,46 @@ def resolve_baseline(args, config):
             sys.exit(2)
     return config.get("baseline", [])
 
+def _scan_stdin(args, exclude, skip_rules, only_rules, no_entropy):
+    scanner = Scanner(
+        ".", excludes=exclude, skip_rules=skip_rules, only_rules=only_rules
+    )
+    scanner.include_entropy = not no_entropy
+    text = sys.stdin.read()
+    return scanner.scan_text(args.filename, text)
+
+
+def _scan_staged(exclude, skip_rules, only_rules):
+    files = staged_files()
+    scanner = Scanner(
+        ".", excludes=exclude, skip_rules=skip_rules, only_rules=only_rules
+    )
+    findings = []
+    for rel in files:
+        candidate = os.path.relpath(rel, scanner.root).replace(os.sep, "/")
+        if scanner._is_binary(candidate) or scanner._is_ignored(candidate):
+            continue
+        text = staged_content(rel)
+        if text is None:
+            continue
+        findings.extend(scanner.scan_text(rel, text))
+    return findings
+
+
+def _scan_path(args, exclude, skip_rules, only_rules, no_entropy):
+    scanner = Scanner(
+        args.path, excludes=exclude, skip_rules=skip_rules, only_rules=only_rules
+    )
+    scanner.include_entropy = not no_entropy
+    return scanner.scan()
+
+
+def _run_scan(args, exclude, skip_rules, only_rules, no_entropy):
+    if args.stdin:
+        return _scan_stdin(args, exclude, skip_rules, only_rules, no_entropy)
+    if args.staged:
+        return _scan_staged(exclude, skip_rules, only_rules)
+    return _scan_path(args, exclude, skip_rules, only_rules, no_entropy)
 
 def cmd_scan(args):
     scan_path = "." if args.staged else args.path
@@ -310,42 +350,7 @@ def cmd_scan(args):
 
     baseline = resolve_baseline(args, config)
 
-    if args.stdin:
-        scanner = Scanner(
-            ".",
-            excludes=exclude,
-            skip_rules=skip_rules,
-            only_rules=only_rules,
-        )
-        scanner.include_entropy = not no_entropy
-        text = sys.stdin.read()
-        findings = scanner.scan_text(args.filename, text)
-    elif args.staged:
-        files = staged_files()
-        scanner = Scanner(
-            ".",
-            excludes=exclude,
-            skip_rules=skip_rules,
-            only_rules=only_rules,
-        )
-        findings = []
-        for rel in files:
-            candidate = os.path.relpath(rel, scanner.root).replace(os.sep, "/")
-            if scanner._is_binary(candidate) or scanner._is_ignored(candidate):
-                continue
-            text = staged_content(rel)
-            if text is None:
-                continue
-            findings.extend(scanner.scan_text(rel, text))
-    else:
-        scanner = Scanner(
-            args.path,
-            excludes=exclude,
-            skip_rules=skip_rules,
-            only_rules=only_rules,
-        )
-        scanner.include_entropy = not no_entropy
-        findings = scanner.scan()
+    findings = _run_scan(args, exclude, skip_rules, only_rules, no_entropy)
 
     findings = filter_baseline(findings, baseline)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -301,6 +301,74 @@ class CliTest(unittest.TestCase):
             result3 = self.run_cli(tmp, "scan", ".")
             self.assertEqual(result3.returncode, 0)
 
+    def test_stdin_scan_detects_secret(self):
+        result = subprocess.run(
+                [sys.executable, "-m", "secretguard", "scan", "--stdin"],
+                input=f"TOKEN = '{SECRET}'",
+                capture_output=True,
+                text=True,
+                cwd=str(PROJECT_ROOT),
+                env={**os.environ, "PYTHONPATH": str(PROJECT_ROOT)},
+                check=False,
+            )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("GitHub Token", result.stdout)
+        self.assertNotIn(SECRET, result.stdout)
+
+    def test_stdin_scan_clean_input_returns_zero(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "secretguard", "scan", "--stdin"],
+            input="print('hello')\n",
+            capture_output=True,
+            text=True,
+            cwd=str(PROJECT_ROOT),
+            env={**os.environ, "PYTHONPATH": str(PROJECT_ROOT)},
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("0 total", result.stdout)
+
+    def test_stdin_scan_reports_default_filename(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "secretguard", "scan", "--stdin"],
+            input=f"TOKEN = '{SECRET}'",
+            capture_output=True,
+            text=True,
+            cwd=str(PROJECT_ROOT),
+            env={**os.environ, "PYTHONPATH": str(PROJECT_ROOT)},
+            check=False,
+        )
+        self.assertIn("stdin:1", result.stdout)
+
+    def test_stdin_scan_reports_custom_filename(self):
+        result = subprocess.run(
+            [
+                sys.executable, "-m", "secretguard", "scan",
+                "--stdin", "--filename", "config.js",
+            ],
+            input=f"TOKEN = '{SECRET}'",
+            capture_output=True,
+            text=True,
+            cwd=str(PROJECT_ROOT),
+            env={**os.environ, "PYTHONPATH": str(PROJECT_ROOT)},
+            check=False,
+        )
+        self.assertIn("config.js:1", result.stdout)
+
+    def test_stdin_scan_json_masks_by_default(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "secretguard", "scan", "--stdin", "--json"],
+            input=f"TOKEN = '{SECRET}'",
+            capture_output=True,
+            text=True,
+            cwd=str(PROJECT_ROOT),
+            env={**os.environ, "PYTHONPATH": str(PROJECT_ROOT)},
+            check=False,
+        )
+        self.assertEqual(result.returncode, 1)
+        self.assertNotIn(SECRET, result.stdout)
+        self.assertIsNotNone(json.loads(result.stdout))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What this changes

Adds `--stdin` and `--filename` flags to `scan`. Fixes #53.

- `--stdin` reads content from stdin instead of a filesystem path, routed through `scan_text` with a synthetic path.
- `--filename` sets the reported path for stdin input (defaults to `stdin`).
- Exit codes match file-based scanning (0 clean, 1 secret found).

Example:
\`\`\`
cat config.js | secret-guard scan --stdin --filename config.js
\`\`\`

## Testing

Added 5 tests in `tests/test_cli.py`: secret detected via stdin, clean input returns 0, default filename reported as `stdin`, custom `--filename` reported correctly, JSON output masks values by default.