### PR TITLE
feat(cli): add --stdin and --filename support to scan piped input

### DIFF
--- a/secretguard/cli.py
+++ b/secretguard/cli.py
@@ -164,6 +164,14 @@ def build_parser():
         "--list-rules", action="store_true",
         help="List every available rule id and exit.",
     )
+    scan.add_argument(
+        "--stdin", action="store_true",
+        help="Scan input from standard input (stdin) instead of path.",
+    )
+    scan.add_argument(
+        "--filename", default="stdin",
+        help="Filename to associate with stdin input (default: stdin).",
+    )
     scan.set_defaults(func=cmd_scan)
 
     hooks = subparsers.add_parser(
@@ -302,7 +310,17 @@ def cmd_scan(args):
 
     baseline = resolve_baseline(args, config)
 
-    if args.staged:
+    if args.stdin:
+        text = sys.stdin.read()
+        scanner = Scanner(
+            ".",
+            excludes=exclude,
+            skip_rules=skip_rules,
+            only_rules=only_rules,
+        )
+        scanner.include_entropy = not no_entropy
+        findings = scanner.scan_text(args.filename, text)
+    elif args.staged:
         files = staged_files()
         scanner = Scanner(
             ".",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,11 +21,12 @@ def run_git(repo, *args):
 
 
 class CliTest(unittest.TestCase):
-    def run_cli(self, cwd, *args):
+    def run_cli(self, cwd, *args, stdin_input=None):
         env = os.environ.copy()
         env["PYTHONPATH"] = str(PROJECT_ROOT)
         return subprocess.run(
             [sys.executable, "-m", "secretguard", *args],
+            input=stdin_input,
             capture_output=True,
             text=True,
             cwd=cwd,
@@ -300,6 +301,30 @@ class CliTest(unittest.TestCase):
             # Runs automatically from config file, suppressed!
             result3 = self.run_cli(tmp, "scan", ".")
             self.assertEqual(result3.returncode, 0)
+
+    def test_scan_stdin_with_secret(self):
+        result = self.run_cli(None, "scan", "--stdin", stdin_input=f"TOKEN = '{SECRET}'")
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("GitHub Token", result.stdout)
+        self.assertIn("stdin:1", result.stdout)
+
+    def test_scan_stdin_clean(self):
+        result = self.run_cli(None, "scan", "--stdin", stdin_input="print('hello')")
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("0 total", result.stdout)
+
+    def test_scan_stdin_custom_filename(self):
+        result = self.run_cli(None, "scan", "--stdin", "--filename", "custom_config.json", stdin_input=f"TOKEN = '{SECRET}'")
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("custom_config.json:1", result.stdout)
+
+    def test_scan_stdin_json_output(self):
+        result = self.run_cli(None, "scan", "--stdin", "--json", stdin_input=f"TOKEN = '{SECRET}'")
+        self.assertEqual(result.returncode, 1)
+        data = json.loads(result.stdout)
+        self.assertGreaterEqual(len(data["findings"]), 1)
+        for finding in data["findings"]:
+            self.assertEqual(finding["path"], "stdin")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Implements --stdin and --filename flags to scan input piped from stdin. Closes #53.