### PR TITLE
feat(cli): add --severity flag to fail scans only past a severity threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ options:
   --only-rule RULE  Run only the given rule id (repeatable)
   --list-rules      List every available rule id and exit
   --baseline FILE   Suppress findings listed in a baseline file
+  --severity LEVEL  Minimum severity threshold to fail the scan (low, medium, high, critical) (default: low)
 ```
 
 ### Taming false positives
@@ -249,7 +250,8 @@ discovers `secret-guard.json` in the scanned directory or any parent:
   "no_entropy": false,
   "skip_rules": ["generic-secret-key"],
   "only_rules": [],
-  "baseline": []
+  "baseline": [],
+  "severity": "low"
 }
 ```
 
@@ -278,10 +280,35 @@ green while new leaks still fail. A baseline file is a JSON document:
 Scanned values are hashed client-side, so the baseline never needs to
 contain the secret itself.
 
-### Exit codes
+### Exit codes and Severity Thresholds
 
-- `0` — no secrets found, or `--help`/`--version`
-- `1` — at least one secret detected (or an error occurred)
+- `0` — no secrets found, or all found secrets are below the `--severity` threshold (or `--help`/`--version` was used)
+- `1` — at least one secret matching or exceeding the `--severity` threshold was detected (or a runtime error occurred)
+- `2` — CLI invocation error or configuration validation failure
+
+#### Severity Levels
+
+The scanner assigns a severity to every finding:
+- `critical`: Private cryptographic keys
+- `high`: Cloud API keys, SaaS tokens, OAuth tokens, and `.env` file credentials
+- `medium`: Variable assignments named like credentials or generic secret keys
+- `low`: High-entropy string detections
+
+By default, the severity threshold is `low`, meaning *any* finding fails the scan (exit code 1).
+
+To only fail the scan on high or critical findings (preventing low-entropy strings or credential variable assignments from breaking CI):
+
+```bash
+secret-guard scan . --severity high
+```
+
+Or set it in your `secret-guard.json` config:
+
+```json
+{
+  "severity": "high"
+}
+```
 
 Use this in CI — the job fails the moment a secret shows up:
 

--- a/secretguard/cli.py
+++ b/secretguard/cli.py
@@ -54,7 +54,13 @@ def find_config(start_path):
 
 CONFIG_FILENAME = "secret-guard.json"
 KNOWN_CONFIG_KEYS = {
-    "//", "exclude", "no_entropy", "skip_rules", "only_rules", "baseline",
+    "//",
+    "exclude",
+    "no_entropy",
+    "skip_rules",
+    "only_rules",
+    "baseline",
+    "severity",
 }
 
 
@@ -110,6 +116,16 @@ def load_config(config_path):
     _require_list_of(data, "skip_rules", str, "strings", config_path)
     _require_list_of(data, "only_rules", str, "strings", config_path)
     _require_list_of(data, "baseline", dict, "objects", config_path)
+    if "severity" in data and data["severity"] not in {
+        "low",
+        "medium",
+        "high",
+        "critical",
+    }:
+        _config_fatal(
+            f"Error: 'severity' in {config_path} must be one of: "
+            "low, medium, high, critical."
+        )
     return data
 
 
@@ -151,6 +167,12 @@ def build_parser():
     scan.add_argument(
         "--baseline", metavar="FILE",
         help="Path to a baseline file containing allowed/suppressed secrets.",
+    )
+    scan.add_argument(
+        "--severity",
+        choices=["low", "medium", "high", "critical"],
+        default=None,
+        help="Minimum severity threshold to fail the scan (default: low).",
     )
     scan.add_argument(
         "--skip-rule", action="append", default=[], metavar="RULE",
@@ -267,6 +289,18 @@ def resolve_baseline(args, config):
     return config.get("baseline", [])
 
 
+def has_blocking_findings(findings, severity_threshold):
+    """Return True if any finding meets or exceeds the severity threshold."""
+
+    levels = {"low": 1, "medium": 2, "high": 3, "critical": 4}
+    threshold_val = levels.get(severity_threshold.lower(), 1)
+    for f in findings:
+        f_sev = f.get("severity", "medium").lower()
+        if levels.get(f_sev, 2) >= threshold_val:
+            return True
+    return False
+
+
 def cmd_scan(args):
     scan_path = "." if args.staged else args.path
     config_file = find_config(scan_path)
@@ -283,6 +317,9 @@ def cmd_scan(args):
         skip_rules = config.get("skip_rules", [])
         only_rules = config.get("only_rules", [])
     no_entropy = args.no_entropy or config.get("no_entropy", False)
+    severity_threshold = getattr(args, "severity", None) or config.get(
+        "severity", "low"
+    )
 
     unknown = unknown_rule_ids(skip_rules + only_rules)
     if unknown:
@@ -344,7 +381,7 @@ def cmd_scan(args):
                 findings, args.path, show_value=args.show_value, color=color
             )
         )
-    return 1 if findings else 0
+    return 1 if has_blocking_findings(findings, severity_threshold) else 0
 
 
 def cmd_init(args):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -301,6 +301,99 @@ class CliTest(unittest.TestCase):
             result3 = self.run_cli(tmp, "scan", ".")
             self.assertEqual(result3.returncode, 0)
 
+    def test_scan_severity_low(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "main.py").write_text(
+                "opaque = 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2'",
+                encoding="utf-8",
+            )
+            result_default = self.run_cli(tmp, "scan", ".")
+            self.assertEqual(result_default.returncode, 1)
+
+            result_low = self.run_cli(tmp, "scan", "--severity", "low", ".")
+            self.assertEqual(result_low.returncode, 1)
+
+            result_med = self.run_cli(tmp, "scan", "--severity", "medium", ".")
+            self.assertEqual(result_med.returncode, 0)
+            self.assertIn("High Entropy String", result_med.stdout)
+
+            result_high = self.run_cli(tmp, "scan", "--severity", "high", ".")
+            self.assertEqual(result_high.returncode, 0)
+
+            result_crit = self.run_cli(tmp, "scan", "--severity", "critical", ".")
+            self.assertEqual(result_crit.returncode, 0)
+
+    def test_scan_severity_medium(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "main.py").write_text(
+                "password = 'somepassword'", encoding="utf-8"
+            )
+            result_med = self.run_cli(tmp, "scan", "--severity", "medium", ".")
+            self.assertEqual(result_med.returncode, 1)
+
+            result_low = self.run_cli(tmp, "scan", "--severity", "low", ".")
+            self.assertEqual(result_low.returncode, 1)
+
+            result_high = self.run_cli(tmp, "scan", "--severity", "high", ".")
+            self.assertEqual(result_high.returncode, 0)
+            self.assertIn("Credential Assignment", result_high.stdout)
+
+            result_crit = self.run_cli(tmp, "scan", "--severity", "critical", ".")
+            self.assertEqual(result_crit.returncode, 0)
+
+    def test_scan_severity_high(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "main.py").write_text(
+                f"TOKEN = '{SECRET}'", encoding="utf-8"
+            )
+            result_high = self.run_cli(tmp, "scan", "--severity", "high", ".")
+            self.assertEqual(result_high.returncode, 1)
+
+            result_med = self.run_cli(tmp, "scan", "--severity", "medium", ".")
+            self.assertEqual(result_med.returncode, 1)
+
+            result_crit = self.run_cli(tmp, "scan", "--severity", "critical", ".")
+            self.assertEqual(result_crit.returncode, 0)
+            self.assertIn("GitHub Token", result_crit.stdout)
+
+    def test_scan_severity_critical(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "main.py").write_text(
+                "-----BEGIN PRIVATE KEY-----", encoding="utf-8"
+            )
+            result_crit = self.run_cli(tmp, "scan", "--severity", "critical", ".")
+            self.assertEqual(result_crit.returncode, 1)
+
+            result_high = self.run_cli(tmp, "scan", "--severity", "high", ".")
+            self.assertEqual(result_high.returncode, 1)
+
+    def test_scan_severity_config_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "main.py").write_text(
+                "password = 'somepassword'", encoding="utf-8"
+            )
+            config_file = Path(tmp, "secret-guard.json")
+            config_content = {"severity": "high"}
+            config_file.write_text(json.dumps(config_content), encoding="utf-8")
+
+            result_config = self.run_cli(tmp, "scan", ".")
+            self.assertEqual(result_config.returncode, 0)
+
+            result_override = self.run_cli(
+                tmp, "scan", "--severity", "medium", "."
+            )
+            self.assertEqual(result_override.returncode, 1)
+
+    def test_scan_severity_config_validation(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            config_file = Path(tmp, "secret-guard.json")
+            config_content = {"severity": "invalid-severity"}
+            config_file.write_text(json.dumps(config_content), encoding="utf-8")
+
+            result = self.run_cli(tmp, "scan", ".")
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("Error: 'severity' in", result.stderr)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Implements the --severity flag and severity configuration parameter in secret-guard.json to let teams configure the minimum severity threshold required to fail a scan. Closes #50.