### PR TITLE
feat: custom rule manifests (closes #9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ options:
   --staged          Scan only files staged in git
   --skip-rule RULE  Never run the given rule id (repeatable)
   --only-rule RULE  Run only the given rule id (repeatable)
+  --rules-path FILE Add custom rules from a JSON manifest
   --list-rules      List every available rule id and exit
   --baseline FILE   Suppress findings listed in a baseline file
   --severity LEVEL  Minimum severity threshold to fail the scan (low, medium, high, critical) (default: low)
@@ -250,6 +251,7 @@ discovers `secret-guard.json` in the scanned directory or any parent:
   "no_entropy": false,
   "skip_rules": ["generic-secret-key"],
   "only_rules": [],
+  "rules": [],
   "baseline": [],
   "severity": "low"
 }
@@ -260,6 +262,49 @@ Command-line flags override config values. Scaffold a starter file with:
 ```bash
 secret-guard init
 ```
+
+### Custom rule manifests
+
+Teams can register their own regex detections without forking. A manifest
+is a JSON object with a `rules` array; each rule needs a `name` and a
+`pattern`, plus optional `severity` (`low`/`medium`/`high`/`critical`,
+default `medium`) and `description`:
+
+```json
+{
+  "rules": [
+    {
+      "name": "Acme API Token",
+      "pattern": "acme_tok_[a-f0-9]{20,}",
+      "severity": "high",
+      "description": "Acme platform API token."
+    }
+  ]
+}
+```
+
+Point a scan at a manifest with `--rules-path`, or commit the rules under
+the `rules` key of `secret-guard.json` (discovered automatically, so it
+works from a gitignored default location too):
+
+```bash
+# From a standalone manifest anywhere on disk
+secret-guard scan . --rules-path .secret-guard/rules.json
+
+# Custom + built-in rules both listed
+secret-guard scan --rules-path .secret-guard/rules.json --list-rules
+```
+
+Custom rules flow through the exact same pipeline as the built-ins: they
+respect `--skip-rule`/`--only-rule` (by their slugified id, e.g.
+`acme-api-token`), honor severity thresholds, and mask matched values by
+default (use `--show-value` to reveal them). A ready-to-copy manifest lives
+in [`examples/rules.json`](examples/rules.json).
+
+Manifests fail fast rather than silently: a duplicate rule name, an
+unreadable regex, an invalid severity, or a missing/malformed file exits
+with code `2` and an actionable message, so a broken manifest can never
+quietly disable detection.
 
 ### Baselines / allowlist
 
@@ -364,7 +409,7 @@ issues per our [Security Policy](SECURITY.md).
 - [ ] Git history scanning
 - [ ] Baseline / allowlist support
 - [ ] SARIF output for GitHub code scanning
-- [ ] Custom rule manifests
+- [x] Custom rule manifests
 
 ## License
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,49 @@
+# Examples
+
+## Custom rule manifest (`rules.json`)
+
+[`rules.json`](rules.json) is a ready-to-copy [custom rule manifest](../README.md#custom-rule-manifests).
+It registers extra regex detections on top of the built-in rules without
+forking secret-guard.
+
+A manifest is a JSON object with a `rules` array. Each rule requires:
+
+- `name` — human-readable label; also slugified into the rule id used by
+  `--skip-rule` / `--only-rule` (e.g. `Acme API Token` → `acme-api-token`).
+- `pattern` — a Python regular expression (matched case-insensitively,
+  multiline).
+
+Each rule optionally accepts:
+
+- `severity` — one of `low`, `medium`, `high`, `critical` (default `medium`).
+- `description` — shown in reports and `--list-rules` output.
+
+### Try it
+
+```bash
+# Add these rules to a scan of the current directory
+secret-guard scan . --rules-path examples/rules.json
+
+# Confirm they registered alongside the built-ins
+secret-guard scan --rules-path examples/rules.json --list-rules
+```
+
+Or commit the same array under the `rules` key of `secret-guard.json` so it
+is discovered automatically (no flag needed):
+
+```json
+{
+  "rules": [
+    {
+      "name": "Acme API Token",
+      "pattern": "acme_tok_[a-f0-9]{20,}",
+      "severity": "high",
+      "description": "Acme platform API token."
+    }
+  ]
+}
+```
+
+Custom rules use the same masking, entropy, severity, and reporting pipeline
+as the built-ins. A duplicate name, unreadable regex, or invalid severity
+fails the scan with exit code `2` instead of being silently ignored.

--- a/examples/rules.json
+++ b/examples/rules.json
@@ -1,0 +1,21 @@
+{
+  "rules": [
+    {
+      "name": "Acme API Token",
+      "pattern": "acme_tok_[a-f0-9]{20,}",
+      "severity": "high",
+      "description": "Acme platform API token."
+    },
+    {
+      "name": "Internal Service Key",
+      "pattern": "svc-[A-Z0-9]{8}-[A-Za-z0-9]{32}",
+      "severity": "critical",
+      "description": "Internal service-to-service signing key."
+    },
+    {
+      "name": "Legacy Session Secret",
+      "pattern": "sess_[A-Za-z0-9]{40}",
+      "description": "Legacy web session secret (defaults to medium severity)."
+    }
+  ]
+}

--- a/secretguard/cli.py
+++ b/secretguard/cli.py
@@ -9,7 +9,15 @@ import sys
 
 from . import __version__
 from .reporter import format_console, format_json
-from .rules import RULES, SPECIAL_RULES, unknown_rule_ids
+from .rules import (
+    RULES,
+    RuleManifestError,
+    SPECIAL_RULES,
+    compile_custom_rules,
+    known_rule_ids,
+    load_rules_file,
+    unknown_rule_ids,
+)
 from .scanner import Scanner
 
 
@@ -59,6 +67,7 @@ KNOWN_CONFIG_KEYS = {
     "no_entropy",
     "skip_rules",
     "only_rules",
+    "rules",
     "baseline",
     "severity",
 }
@@ -183,6 +192,10 @@ def build_parser():
         help="Run only the given rule id (repeatable).",
     )
     scan.add_argument(
+        "--rules-path", metavar="FILE",
+        help="Path to a JSON manifest of custom rules to add to the built-ins.",
+    )
+    scan.add_argument(
         "--list-rules", action="store_true",
         help="List every available rule id and exit.",
     )
@@ -242,7 +255,7 @@ def staged_content(path):
         return None
 
 
-def list_rules():
+def list_rules(custom_rules=None):
     """Print every available rule id with name, severity, and description."""
 
     def fmt(info):
@@ -253,6 +266,10 @@ def list_rules():
     print("Regex rules:")
     for rule in RULES:
         print(fmt(rule))
+    if custom_rules:
+        print("\nCustom rules:")
+        for rule in custom_rules:
+            print(fmt(rule))
     print("\nSpecial rules:")
     for info in SPECIAL_RULES.values():
         print(fmt(info))
@@ -296,19 +313,21 @@ def resolve_baseline(args, config):
             sys.exit(2)
     return config.get("baseline", [])
 
-def _scan_stdin(args, exclude, skip_rules, only_rules, no_entropy):
+def _scan_stdin(args, exclude, skip_rules, only_rules, no_entropy, custom_rules):
     scanner = Scanner(
-        ".", excludes=exclude, skip_rules=skip_rules, only_rules=only_rules
+        ".", excludes=exclude, skip_rules=skip_rules, only_rules=only_rules,
+        custom_rules=custom_rules,
     )
     scanner.include_entropy = not no_entropy
     text = sys.stdin.read()
     return scanner.scan_text(args.filename, text)
 
 
-def _scan_staged(exclude, skip_rules, only_rules):
+def _scan_staged(exclude, skip_rules, only_rules, custom_rules):
     files = staged_files()
     scanner = Scanner(
-        ".", excludes=exclude, skip_rules=skip_rules, only_rules=only_rules
+        ".", excludes=exclude, skip_rules=skip_rules, only_rules=only_rules,
+        custom_rules=custom_rules,
     )
     findings = []
     for rel in files:
@@ -322,20 +341,25 @@ def _scan_staged(exclude, skip_rules, only_rules):
     return findings
 
 
-def _scan_path(args, exclude, skip_rules, only_rules, no_entropy):
+def _scan_path(args, exclude, skip_rules, only_rules, no_entropy, custom_rules):
     scanner = Scanner(
-        args.path, excludes=exclude, skip_rules=skip_rules, only_rules=only_rules
+        args.path, excludes=exclude, skip_rules=skip_rules, only_rules=only_rules,
+        custom_rules=custom_rules,
     )
     scanner.include_entropy = not no_entropy
     return scanner.scan()
 
 
-def _run_scan(args, exclude, skip_rules, only_rules, no_entropy):
+def _run_scan(args, exclude, skip_rules, only_rules, no_entropy, custom_rules):
     if args.stdin:
-        return _scan_stdin(args, exclude, skip_rules, only_rules, no_entropy)
+        return _scan_stdin(
+            args, exclude, skip_rules, only_rules, no_entropy, custom_rules
+        )
     if args.staged:
-        return _scan_staged(exclude, skip_rules, only_rules)
-    return _scan_path(args, exclude, skip_rules, only_rules, no_entropy)
+        return _scan_staged(exclude, skip_rules, only_rules, custom_rules)
+    return _scan_path(
+        args, exclude, skip_rules, only_rules, no_entropy, custom_rules
+    )
 
 def has_blocking_findings(findings, severity_threshold):
     """Return True if any finding meets or exceeds the severity threshold."""
@@ -347,6 +371,28 @@ def has_blocking_findings(findings, severity_threshold):
         if levels.get(f_sev, 2) >= threshold_val:
             return True
     return False
+
+
+def _load_custom_rules(args, config, config_file):
+    """Compile custom rules from config['rules'] and --rules-path.
+
+    Both sources share one id namespace with the built-in rules, so a name
+    that collides anywhere fails the scan. Any manifest problem is reported
+    as a fatal configuration error (exit code 2) rather than ignored.
+    """
+
+    seen = {rid: "a built-in rule" for rid in known_rule_ids()}
+    custom = []
+    try:
+        if "rules" in config:
+            custom += compile_custom_rules(
+                config["rules"], source=config_file, seen=seen
+            )
+        if getattr(args, "rules_path", None):
+            custom += load_rules_file(args.rules_path, seen=seen)
+    except RuleManifestError as exc:
+        _config_fatal(f"Error: {exc}")
+    return custom
 
 
 def cmd_scan(args):
@@ -369,7 +415,9 @@ def cmd_scan(args):
         "severity", "low"
     )
 
-    unknown = unknown_rule_ids(skip_rules + only_rules)
+    custom_rules = _load_custom_rules(args, config, config_file)
+
+    unknown = unknown_rule_ids(skip_rules + only_rules, custom_rules)
     if unknown:
         print(
             "unknown rule id{}: {}".format(
@@ -383,11 +431,13 @@ def cmd_scan(args):
         return 2
 
     if args.list_rules:
-        return list_rules()
+        return list_rules(custom_rules)
 
     baseline = resolve_baseline(args, config)
 
-    findings = _run_scan(args, exclude, skip_rules, only_rules, no_entropy)
+    findings = _run_scan(
+        args, exclude, skip_rules, only_rules, no_entropy, custom_rules
+    )
 
     findings = filter_baseline(findings, baseline)
 
@@ -425,6 +475,7 @@ def cmd_init(args):
         "no_entropy": False,
         "skip_rules": [],
         "only_rules": [],
+        "rules": [],
     }
 
     try:

--- a/secretguard/cli.py
+++ b/secretguard/cli.py
@@ -11,8 +11,8 @@ from . import __version__
 from .reporter import format_console, format_json
 from .rules import (
     RULES,
-    RuleManifestError,
     SPECIAL_RULES,
+    RuleManifestError,
     compile_custom_rules,
     known_rule_ids,
     load_rules_file,

--- a/secretguard/rules.py
+++ b/secretguard/rules.py
@@ -1,5 +1,6 @@
 """Detection rules: regex patterns and entropy heuristics."""
 
+import json
 import math
 import re
 
@@ -218,35 +219,158 @@ def entropy_candidates(text):
             yield match.start(), match.end(), entropy, value
 
 
-def known_rule_ids():
+def known_rule_ids(custom_rules=None):
     """Return every rule id the scanner can run in a scan."""
 
-    return [rule["id"] for rule in RULES] + list(SPECIAL_RULE_IDS)
+    ids = [rule["id"] for rule in RULES] + list(SPECIAL_RULE_IDS)
+    ids += [rule["id"] for rule in custom_rules or ()]
+    return ids
 
 
-def unknown_rule_ids(rule_ids):
+def unknown_rule_ids(rule_ids, custom_rules=None):
     """Return the rule ids supplied on the CLI that do not exist."""
 
-    known = set(known_rule_ids())
+    known = set(known_rule_ids(custom_rules))
     return sorted({rule_id for rule_id in rule_ids if rule_id not in known})
 
 
-def matches_rules(text, skip_rules=None, only_rules=None):
+VALID_SEVERITIES = ("low", "medium", "high", "critical")
+
+
+class RuleManifestError(ValueError):
+    """Raised when a custom rule manifest is invalid.
+
+    Carries an actionable, human-readable message so callers can surface it
+    and fail the scan instead of silently ignoring a broken manifest.
+    """
+
+
+def compile_custom_rules(raw_rules, source="custom rules", seen=None):
+    """Validate user-defined rules and compile them into built-in-shaped dicts.
+
+    ``raw_rules`` is a list of dicts with keys ``name`` and ``pattern`` (plus
+    optional ``severity`` and ``description``). ``source`` names the manifest
+    in error messages. ``seen`` maps already-claimed rule ids to a human
+    label; it is seeded with the built-in ids when omitted and updated in
+    place, so a caller can compile several manifests and still catch
+    cross-manifest duplicates. Raises ``RuleManifestError`` on the first
+    problem found.
+    """
+
+    if seen is None:
+        seen = {rid: "a built-in rule" for rid in known_rule_ids()}
+    if not isinstance(raw_rules, list):
+        raise RuleManifestError(f"'rules' in {source} must be a list.")
+
+    compiled = []
+    for index, item in enumerate(raw_rules, 1):
+        where = f"{source} (rule #{index})"
+        if not isinstance(item, dict):
+            raise RuleManifestError(f"{where} must be a JSON object.")
+
+        name = item.get("name")
+        if not isinstance(name, str) or not name.strip():
+            raise RuleManifestError(f"{where} is missing a non-empty 'name'.")
+        name = name.strip()
+
+        pattern = item.get("pattern")
+        if not isinstance(pattern, str) or not pattern:
+            raise RuleManifestError(
+                f"rule '{name}' in {source} is missing a non-empty 'pattern'."
+            )
+
+        severity = item.get("severity", "medium")
+        if severity not in VALID_SEVERITIES:
+            raise RuleManifestError(
+                f"rule '{name}' in {source} has invalid severity "
+                f"{severity!r}; expected one of {', '.join(VALID_SEVERITIES)}."
+            )
+
+        description = item.get("description", "")
+        if not isinstance(description, str):
+            raise RuleManifestError(
+                f"rule '{name}' in {source} has a non-string 'description'."
+            )
+
+        rule_id = _slugify(name)
+        if not rule_id:
+            raise RuleManifestError(
+                f"rule name '{name}' in {source} does not yield a valid id."
+            )
+        if rule_id in seen:
+            raise RuleManifestError(
+                f"duplicate rule id '{rule_id}' from '{name}' in {source} "
+                f"conflicts with {seen[rule_id]}."
+            )
+
+        try:
+            compiled_pattern = re.compile(pattern, re.MULTILINE | re.IGNORECASE)
+        except re.error as exc:
+            raise RuleManifestError(
+                f"rule '{name}' in {source} has an invalid regex: {exc}."
+            ) from exc
+
+        seen[rule_id] = f"rule '{name}'"
+        compiled.append(
+            {
+                "id": rule_id,
+                "name": name,
+                "pattern": compiled_pattern,
+                "severity": severity,
+                "description": description,
+                "custom": True,
+            }
+        )
+    return compiled
+
+
+def load_rules_file(path, seen=None):
+    """Read a JSON rule manifest from ``path`` and return compiled rules.
+
+    The manifest is a JSON object with a top-level ``rules`` array. Any read,
+    parse, or schema problem is raised as ``RuleManifestError`` so the CLI can
+    fail the scan with an actionable message.
+    """
+
+    try:
+        with open(path, encoding="utf-8") as handle:
+            data = json.load(handle)
+    except FileNotFoundError as exc:
+        raise RuleManifestError(f"rules file not found: {path}") from exc
+    except OSError as exc:
+        raise RuleManifestError(
+            f"could not read rules file {path}: {exc}"
+        ) from exc
+    except json.JSONDecodeError as exc:
+        raise RuleManifestError(
+            f"could not parse rules file {path}: {exc}"
+        ) from exc
+
+    if not isinstance(data, dict) or "rules" not in data:
+        raise RuleManifestError(
+            f"rules file {path} must be a JSON object with a 'rules' array."
+        )
+    return compile_custom_rules(data["rules"], source=path, seen=seen)
+
+
+def matches_rules(text, skip_rules=None, only_rules=None, rules=None):
     """Run regex rules against text, honoring rule-id filters.
 
     Only runs the intersection of `only_rules` (when given) with everything
-    except `skip_rules`. Yields findings as (rule, match).
+    except `skip_rules`. `rules` defaults to the built-in RULES; callers pass
+    built-ins plus custom rules to include them. Yields (rule, match).
     """
 
+    rules = RULES if rules is None else rules
     skips = set(skip_rules or ())
     if only_rules:
         enabled = [
             rule
-            for rule in RULES
+            for rule in rules
             if rule["id"] in only_rules and rule["id"] not in skips
         ]
     else:
-        enabled = [rule for rule in RULES if rule["id"] not in skips]
+        enabled = [rule for rule in rules if rule["id"] not in skips]
     for rule in enabled:
         for match in rule["pattern"].finditer(text):
             yield rule, match

--- a/secretguard/scanner.py
+++ b/secretguard/scanner.py
@@ -13,6 +13,7 @@ except ImportError:  # pragma: no cover - optional dependency
 from .rules import (
     DOTENV_RULE_ID,
     ENTROPY_RULE_ID,
+    RULES,
     dotenv_secret_assignments,
     entropy_candidates,
     is_dotenv_path,
@@ -43,12 +44,14 @@ class Scanner:
         include_entropy=True,
         skip_rules=None,
         only_rules=None,
+        custom_rules=None,
     ):
         self.root = os.path.abspath(root)
         self.extra_excludes = set(excludes or [])
         self.include_entropy = include_entropy
         self.skip_rules = set(skip_rules or [])
         self.only_rules = set(only_rules or []) or None
+        self.custom_rules = list(custom_rules or [])
         self._spec = None
         self._load_gitignore()
 
@@ -152,7 +155,8 @@ class Scanner:
 
         skip_rules = sorted(self.skip_rules)
         only_rules = sorted(self.only_rules) if self.only_rules else None
-        for rule, match in matches_rules(text, skip_rules, only_rules):
+        rules = RULES + self.custom_rules
+        for rule, match in matches_rules(text, skip_rules, only_rules, rules):
             line = line_number(text, match.start())
             if line in key_lines:
                 continue

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,6 +12,19 @@ from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 SECRET = "ghp_1234567890abcdefghijklmnopqrstuvwxyz"
+CUSTOM_SECRET = "acme_tok_0123456789abcdef0123"
+CUSTOM_MANIFEST = json.dumps(
+    {
+        "rules": [
+            {
+                "name": "Acme Token",
+                "pattern": "acme_tok_[a-f0-9]{20,}",
+                "severity": "high",
+                "description": "Acme platform API token.",
+            }
+        ]
+    }
+)
 
 
 def run_git(repo, *args):
@@ -461,6 +474,139 @@ class CliTest(unittest.TestCase):
         self.assertEqual(result.returncode, 1)
         self.assertNotIn(SECRET, result.stdout)
         self.assertIsNotNone(json.loads(result.stdout))
+
+
+class CustomRuleCliTest(unittest.TestCase):
+    def run_cli(self, cwd, *args):
+        env = os.environ.copy()
+        env["PYTHONPATH"] = str(PROJECT_ROOT)
+        return subprocess.run(
+            [sys.executable, "-m", "secretguard", *args],
+            capture_output=True,
+            text=True,
+            cwd=cwd,
+            env=env,
+            check=False,
+        )
+
+    def test_rules_path_relative_detects_custom_secret(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "rules.json").write_text(CUSTOM_MANIFEST, encoding="utf-8")
+            Path(tmp, "app.py").write_text(
+                f"api = '{CUSTOM_SECRET}'", encoding="utf-8"
+            )
+            result = self.run_cli(
+                tmp, "scan", "--rules-path", "rules.json", "."
+            )
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("Acme Token", result.stdout)
+
+    def test_config_embedded_rules_are_discovered(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "secret-guard.json").write_text(
+                CUSTOM_MANIFEST, encoding="utf-8"
+            )
+            Path(tmp, "app.py").write_text(
+                f"api = '{CUSTOM_SECRET}'", encoding="utf-8"
+            )
+            result = self.run_cli(tmp, "scan", ".")
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("Acme Token", result.stdout)
+
+    def test_custom_value_masked_by_default(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "rules.json").write_text(CUSTOM_MANIFEST, encoding="utf-8")
+            Path(tmp, "app.py").write_text(
+                f"api = '{CUSTOM_SECRET}'", encoding="utf-8"
+            )
+            result = self.run_cli(
+                tmp, "scan", "--json", "--rules-path", "rules.json", "."
+            )
+            self.assertEqual(result.returncode, 1)
+            self.assertNotIn(CUSTOM_SECRET, result.stdout)
+
+    def test_custom_value_revealed_with_show_value(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "rules.json").write_text(CUSTOM_MANIFEST, encoding="utf-8")
+            Path(tmp, "app.py").write_text(
+                f"api = '{CUSTOM_SECRET}'", encoding="utf-8"
+            )
+            result = self.run_cli(
+                tmp, "scan", "--json", "--show-value",
+                "--rules-path", "rules.json", ".",
+            )
+            self.assertEqual(result.returncode, 1)
+            self.assertIn(CUSTOM_SECRET, result.stdout)
+
+    def test_list_rules_includes_custom(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "rules.json").write_text(CUSTOM_MANIFEST, encoding="utf-8")
+            result = self.run_cli(
+                tmp, "scan", "--rules-path", "rules.json", "--list-rules"
+            )
+            self.assertEqual(result.returncode, 0)
+            self.assertIn("Custom rules:", result.stdout)
+            self.assertIn("acme-token", result.stdout)
+
+    def test_invalid_regex_fails_scan(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "rules.json").write_text(
+                '{"rules": [{"name": "Bad", "pattern": "([A-Z"}]}',
+                encoding="utf-8",
+            )
+            Path(tmp, "app.py").write_text("x = 1\n", encoding="utf-8")
+            result = self.run_cli(
+                tmp, "scan", "--rules-path", "rules.json", "."
+            )
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("invalid regex", result.stderr)
+
+    def test_unknown_severity_fails_scan(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "rules.json").write_text(
+                '{"rules": [{"name": "X", "pattern": "abc", '
+                '"severity": "urgent"}]}',
+                encoding="utf-8",
+            )
+            Path(tmp, "app.py").write_text("x = 1\n", encoding="utf-8")
+            result = self.run_cli(
+                tmp, "scan", "--rules-path", "rules.json", "."
+            )
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("invalid severity", result.stderr)
+
+    def test_duplicate_name_fails_scan(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "rules.json").write_text(
+                '{"rules": [{"name": "Dup", "pattern": "a"}, '
+                '{"name": "Dup", "pattern": "b"}]}',
+                encoding="utf-8",
+            )
+            Path(tmp, "app.py").write_text("x = 1\n", encoding="utf-8")
+            result = self.run_cli(
+                tmp, "scan", "--rules-path", "rules.json", "."
+            )
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("duplicate rule id", result.stderr)
+
+    def test_missing_rules_file_fails_scan(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "app.py").write_text("x = 1\n", encoding="utf-8")
+            result = self.run_cli(
+                tmp, "scan", "--rules-path", "nope.json", "."
+            )
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("not found", result.stderr)
+
+    def test_init_scaffolds_rules_key(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            result = self.run_cli(tmp, "init")
+            self.assertEqual(result.returncode, 0)
+            data = json.loads(
+                Path(tmp, "secret-guard.json").read_text(encoding="utf-8")
+            )
+            self.assertIn("rules", data)
+            self.assertEqual(data["rules"], [])
 
 
 if __name__ == "__main__":

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1,11 +1,18 @@
 """Unit tests for detection rules and entropy heuristics."""
 
+import os
+import shutil
+import tempfile
 import unittest
 
 from secretguard.rules import (
+    RULES,
+    RuleManifestError,
+    compile_custom_rules,
     dotenv_secret_assignments,
     entropy_candidates,
     is_dotenv_path,
+    load_rules_file,
     matches_rules,
     shannon_entropy,
 )
@@ -352,6 +359,102 @@ class DotenvValueParsingTest(unittest.TestCase):
         # this way; parsing logic itself doesn't care about the filename.
         self.assertFalse(is_dotenv_path("config.py"))
 
+
+class CustomRuleCompileTest(unittest.TestCase):
+    def _compile_one(self, **overrides):
+        rule = {
+            "name": "My API Token",
+            "pattern": "mytok_[A-Za-z0-9]{20,}",
+            "severity": "high",
+            "description": "Acme platform token",
+        }
+        rule.update(overrides)
+        return compile_custom_rules([rule])
+
+    def test_happy_path_compiles_rule(self):
+        rules = self._compile_one()
+        self.assertEqual(len(rules), 1)
+        self.assertEqual(rules[0]["id"], "my-api-token")
+        self.assertEqual(rules[0]["severity"], "high")
+        self.assertEqual(rules[0]["description"], "Acme platform token")
+        self.assertTrue(rules[0]["custom"])
+
+    def test_compiled_rule_detects_via_matches_rules(self):
+        rules = self._compile_one()
+        names = [
+            rule["name"]
+            for rule, _ in matches_rules(
+                "k = mytok_abcdefghij0123456789", rules=RULES + rules
+            )
+        ]
+        self.assertIn("My API Token", names)
+
+    def test_severity_defaults_to_medium(self):
+        rules = compile_custom_rules([{"name": "X", "pattern": "abc"}])
+        self.assertEqual(rules[0]["severity"], "medium")
+
+    def test_invalid_regex_raises(self):
+        with self.assertRaises(RuleManifestError):
+            compile_custom_rules([{"name": "Bad", "pattern": "([A-Z"}])
+
+    def test_unknown_severity_raises(self):
+        with self.assertRaises(RuleManifestError):
+            self._compile_one(severity="urgent")
+
+    def test_duplicate_name_raises(self):
+        with self.assertRaises(RuleManifestError):
+            compile_custom_rules(
+                [{"name": "Dup", "pattern": "a"}, {"name": "Dup", "pattern": "b"}]
+            )
+
+    def test_collision_with_builtin_id_raises(self):
+        with self.assertRaises(RuleManifestError):
+            compile_custom_rules([{"name": "GitHub Token", "pattern": "a"}])
+
+    def test_missing_pattern_raises(self):
+        with self.assertRaises(RuleManifestError):
+            compile_custom_rules([{"name": "NoPattern"}])
+
+    def test_missing_name_raises(self):
+        with self.assertRaises(RuleManifestError):
+            compile_custom_rules([{"pattern": "abc"}])
+
+    def test_rules_must_be_a_list(self):
+        with self.assertRaises(RuleManifestError):
+            compile_custom_rules({"name": "X", "pattern": "abc"})
+
+
+class LoadRulesFileTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self._tmp, True)
+
+    def _write(self, content):
+        path = os.path.join(self._tmp, "rules.json")
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write(content)
+        return path
+
+    def test_loads_valid_manifest(self):
+        path = self._write(
+            '{"rules": [{"name": "Tok", "pattern": "tok_[0-9]{4}"}]}'
+        )
+        rules = load_rules_file(path)
+        self.assertEqual(rules[0]["id"], "tok")
+
+    def test_missing_file_raises(self):
+        with self.assertRaises(RuleManifestError):
+            load_rules_file(os.path.join(self._tmp, "nope.json"))
+
+    def test_malformed_json_raises(self):
+        path = self._write('{"rules": [')
+        with self.assertRaises(RuleManifestError):
+            load_rules_file(path)
+
+    def test_missing_rules_key_raises(self):
+        path = self._write('{"other": []}')
+        with self.assertRaises(RuleManifestError):
+            load_rules_file(path)
 
 
 if __name__ == "__main__":

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -5,9 +5,11 @@ import shutil
 import tempfile
 import unittest
 
+from secretguard.rules import compile_custom_rules
 from secretguard.scanner import HAS_PATHSPEC, Scanner, line_number
 
 TOKEN = "ghp_1234567890abcdefghijklmnopqrstuvwxyz"
+CUSTOM_SECRET = "acme_tok_0123456789abcdef0123"
 
 
 def has_rule(findings, rule):
@@ -148,6 +150,70 @@ class ScannerTest(unittest.TestCase):
         self.assertEqual(line_number("", 0), 1)
         self.assertEqual(line_number("a\nb\nc", 0), 1)
         self.assertEqual(line_number("a\nb\nc", 4), 3)
+
+
+class CustomRuleScannerTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self._tmp, True)
+
+    def write(self, rel, content):
+        path = os.path.join(self._tmp, rel)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write(content)
+        return path
+
+    def custom_rules(self):
+        return compile_custom_rules(
+            [
+                {
+                    "name": "Acme Token",
+                    "pattern": "acme_tok_[a-f0-9]{20,}",
+                    "severity": "critical",
+                    "description": "Acme platform API token.",
+                }
+            ]
+        )
+
+    def make_scanner(self, **kwargs):
+        kwargs.setdefault("root", self._tmp)
+        kwargs.setdefault("custom_rules", self.custom_rules())
+        return Scanner(**kwargs)
+
+    def test_custom_rule_detects_secret(self):
+        self.write("config.py", f"api = '{CUSTOM_SECRET}'")
+        findings = self.make_scanner().scan()
+        self.assertTrue(has_rule(findings, "Acme Token"))
+
+    def test_custom_rule_carries_severity_and_description(self):
+        self.write("config.py", f"api = '{CUSTOM_SECRET}'")
+        finding = next(
+            f for f in self.make_scanner().scan() if f["rule"] == "Acme Token"
+        )
+        self.assertEqual(finding["severity"], "critical")
+        self.assertEqual(finding["rule_id"], "acme-token")
+        self.assertEqual(finding["description"], "Acme platform API token.")
+
+    def test_custom_rule_runs_alongside_builtins(self):
+        self.write("config.py", f"gh = {TOKEN}\napi = '{CUSTOM_SECRET}'")
+        rules = [f["rule"] for f in self.make_scanner().scan()]
+        self.assertIn("Acme Token", rules)
+        self.assertIn("GitHub Token", rules)
+
+    def test_custom_rule_respects_only_rule(self):
+        self.write("config.py", f"gh = {TOKEN}\napi = '{CUSTOM_SECRET}'")
+        scanner = self.make_scanner(only_rules=["acme-token"])
+        rules = [f["rule"] for f in scanner.scan()]
+        self.assertIn("Acme Token", rules)
+        self.assertNotIn("GitHub Token", rules)
+
+    def test_custom_rule_respects_skip_rule(self):
+        self.write("config.py", f"api = '{CUSTOM_SECRET}'")
+        scanner = self.make_scanner(
+            skip_rules=["acme-token"], include_entropy=False
+        )
+        self.assertFalse(has_rule(scanner.scan(), "Acme Token"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Implements #9 — let teams register custom regex detection rules via JSON without forking.

## What
- `--rules-path FILE` to load a JSON manifest, and/or a `rules` array in `secret-guard.json` (auto-discovered from the scanned dir or any parent, so it works from a gitignored default location too)
- Manifest schema: `{ "rules": [ { "name", "pattern", "severity"?, "description"? } ] }` (severity defaults to `medium`)
- Custom rules run through the same pipeline as built-ins: masking, entropy, severity thresholds, `--skip-rule`/`--only-rule` (by slugified id, e.g. `acme-api-token`), and `--list-rules`
- Values are masked by default; `--show-value` reveals them

## Validation (fails the scan, exit code 2 — never silently ignored)
- duplicate rule name / id collision with a built-in
- unreadable regex
- invalid severity
- missing or malformed manifest file

## Tests
Added coverage for happy path, invalid regex, unknown severity, duplicate name, plus masking and relative-path + config discovery. Full suite: 155 passing.

## Docs
README "Custom rule manifests" section + a ready-to-copy `examples/rules.json`.

Zero new runtime dependencies (stdlib `json` only).