### PR TITLE
feat(rules): add PyPI, Shopify, Mailgun, and database connection URI rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,16 @@ before they reach your git history.
 
 ## What it does
 
-secret-guard scans source files for hardcoded credentials using **13 pattern
+secret-guard scans source files for hardcoded credentials using **30 pattern
 rules** plus **Shannon-entropy detection**, and reports each finding with a
 severity and a **masked** value. By default it never prints the secret itself.
 
 | Category | Rules |
 | --- | --- |
-| Cloud / SaaS | AWS Access Key IDs, AWS temporary & dashed keys, Google API Keys, Stripe live keys |
-| Tokens | GitHub PAT (classic & fine-grained), Slack tokens, Square access tokens, JWTs |
+| Cloud / SaaS | AWS Access Key IDs, AWS temporary & dashed keys, Google API Keys, Stripe live keys, Shopify access tokens, Mailgun API keys |
+| Tokens | GitHub PAT (classic & fine-grained), Slack tokens, Square access tokens, JWTs, PyPI API tokens, npm/Hugging Face/GitLab tokens |
 | Key material | RSA / EC / DSA / OpenSSH / PGP private keys (`CRITICAL`) |
+| Databases | PostgreSQL and MongoDB connection URIs with embedded credentials |
 | Heuristics | Generic secret keys, credential assignments, high-entropy strings |
 
 On top of pattern matching, `secret-guard` catches **`.env` files** with

--- a/secretguard/rules.py
+++ b/secretguard/rules.py
@@ -185,13 +185,13 @@ RULES = [
         description="Mailgun API key.",
     ),
     _r(
-        r"postgresql://[^:]+:[^@]+@[^/]+(?:/[^?]+)?",
+        r"\bpostgresql://[^:\s/]+:[^@\s/]+@(?:[A-Za-z0-9.-]+|\[[0-9a-f:]+\])(?::\d+)?(?:/[^\s]*)?",
         "PostgreSQL Connection URI",
         severity="high",
         description="PostgreSQL connection URI containing credentials.",
     ),
     _r(
-        r"mongodb(?:\+srv)?://[^:]+:[^@]+@[^/]+(?:/[^?]+)?",
+        r"\bmongodb(?:\+srv)?://[^:\s/]+:[^@\s/]+@(?:[A-Za-z0-9.-]+|\[[0-9a-f:]+\])(?::\d+)?(?:/[^\s]*)?",
         "MongoDB Connection URI",
         severity="high",
         description="MongoDB connection URI containing credentials.",

--- a/secretguard/rules.py
+++ b/secretguard/rules.py
@@ -167,6 +167,36 @@ RULES = [
         description="Slack Incoming Webhook URL.",
     ),
     _r(
+        r"pypi-[a-z0-9_.-]{50,}",
+        "PyPI API Token",
+        severity="high",
+        description="PyPI API access token.",
+    ),
+    _r(
+        r"shp(at|ca|pa|ua|ss)_[a-f0-9]{32}",
+        "Shopify Access Token",
+        severity="high",
+        description="Shopify API access token or secret.",
+    ),
+    _r(
+        r"key-[a-z0-9]{32}",
+        "Mailgun API Key",
+        severity="high",
+        description="Mailgun API key.",
+    ),
+    _r(
+        r"postgresql://[^:]+:[^@]+@[^/]+(?:/[^?]+)?",
+        "PostgreSQL Connection URI",
+        severity="high",
+        description="PostgreSQL connection URI containing credentials.",
+    ),
+    _r(
+        r"mongodb(?:\+srv)?://[^:]+:[^@]+@[^/]+(?:/[^?]+)?",
+        "MongoDB Connection URI",
+        severity="high",
+        description="MongoDB connection URI containing credentials.",
+    ),
+    _r(
         r"sk-[0-9a-fA-F]{32,}",
         "Generic Secret Key",
         severity="medium",

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -197,7 +197,10 @@ class RuleDetectionTest(unittest.TestCase):
         )
 
     def test_pypi_api_token(self):
-        token = "pypi-" + "AgEIcHlwaS5vcmcNDExxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        token = (
+            "pypi-"
+            + "AgEIcHlwaS5vcmcNDExxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        )
         self.assertIn(
             "PyPI API Token",
             rule_names(f"token = {token}"),

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -196,6 +196,48 @@ class RuleDetectionTest(unittest.TestCase):
             rule_names(f"webhook = {webhook_url}"),
         )
 
+    def test_pypi_api_token(self):
+        token = "pypi-" + "AgEIcHlwaS5vcmcNDExxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        self.assertIn(
+            "PyPI API Token",
+            rule_names(f"token = {token}"),
+        )
+
+    def test_shopify_access_token(self):
+        token1 = "shpat_" + "0123456789abcdef0123456789abcdef"
+        token2 = "shpca_" + "0123456789abcdef0123456789abcdef"
+        self.assertIn(
+            "Shopify Access Token",
+            rule_names(f"token = {token1}"),
+        )
+        self.assertIn(
+            "Shopify Access Token",
+            rule_names(f"token = {token2}"),
+        )
+
+    def test_mailgun_api_key(self):
+        key = "key-" + "0123456789abcdef0123456789abcdef"
+        self.assertIn(
+            "Mailgun API Key",
+            rule_names(f"api_key = {key}"),
+        )
+
+    def test_postgresql_connection_uri(self):
+        self.assertIn(
+            "PostgreSQL Connection URI",
+            rule_names("db = postgresql://user:password@localhost:5432/mydb"),
+        )
+
+    def test_mongodb_connection_uri(self):
+        self.assertIn(
+            "MongoDB Connection URI",
+            rule_names("db = mongodb://user:password@localhost:27017/mydb"),
+        )
+        self.assertIn(
+            "MongoDB Connection URI",
+            rule_names("db = mongodb+srv://user:password@cluster.example.com/mydb"),
+        )
+
     def test_generic_secret_key(self):
         self.assertIn(
             "Generic Secret Key",


### PR DESCRIPTION
Resolves Rajeev91691's #73 after fixing two CI failures:
- lint: wrapped the over-long PyPI token test line (E501).
- scan: tightened the PostgreSQL/MongoDB connection-URI regexes to require a real hostname so they no longer match their own literal definition, fixing the repo self-scan (was 1 high finding, now 0).

All 163 tests pass; ruff clean; self-scan clean.