### PR TITLE
ci(publish): trigger PyPI publish on release published events

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,8 @@
 name: Publish to PyPI
 
 on:
-  push:
-    tags: ["v*"]
+  release:
+    types: [published]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Fixes stale PyPI publish root cause: release-please tags releases via the GitHub API (no git tag push), so the previous on: push: tags trigger never fired for v0.5.0/v0.6.0. Switch to on: release: types: [published] which fires for API/UI releases too; keep workflow_dispatch.