### PR TITLE
feat(cli): add --sarif output format for GitHub Code Scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ options:
   --exclude DIR     Skip additional directory names (repeatable)
   --no-entropy      Disable high-entropy string detection
   --json            Output findings as JSON
+  --sarif           Output findings in SARIF format
   --show-value      Print full secret values (default masks them)
   --staged          Scan only files staged in git
   --skip-rule RULE  Never run the given rule id (repeatable)
@@ -407,8 +408,8 @@ issues per our [Security Policy](SECURITY.md).
 - [x] git hook + pre-commit integration
 - [x] OIDC trusted publishing to PyPI
 - [ ] Git history scanning
-- [ ] Baseline / allowlist support
-- [ ] SARIF output for GitHub code scanning
+- [x] Baseline / allowlist support
+- [x] SARIF output for GitHub code scanning
 - [x] Custom rule manifests
 
 ## License

--- a/secretguard/cli.py
+++ b/secretguard/cli.py
@@ -8,7 +8,7 @@ import subprocess
 import sys
 
 from . import __version__
-from .reporter import format_console, format_json
+from .reporter import format_console, format_json, format_sarif
 from .rules import (
     RULES,
     SPECIAL_RULES,
@@ -160,6 +160,9 @@ def build_parser():
     )
     scan.add_argument(
         "--json", action="store_true", help="Output JSON instead of a report.",
+    )
+    scan.add_argument(
+        "--sarif", action="store_true", help="Output findings in SARIF format.",
     )
     scan.add_argument(
         "--show-value", action="store_true",
@@ -445,6 +448,16 @@ def cmd_scan(args):
         print(
             format_json(
                 findings, os.path.abspath(args.path), show_value=args.show_value
+            )
+        )
+    elif args.sarif:
+        print(
+            format_sarif(
+                findings,
+                os.path.abspath(args.path),
+                show_value=args.show_value,
+                version=__version__,
+                custom_rules=custom_rules,
             )
         )
     else:

--- a/secretguard/reporter.py
+++ b/secretguard/reporter.py
@@ -95,3 +95,117 @@ def format_json(findings, root, show_value=False):
         {"schema_version": SCHEMA_VERSION, "root": root, "findings": sanitized},
         indent=2,
     )
+
+
+def format_sarif(findings, root, show_value=False, version="0.6.0", custom_rules=None):
+    from .rules import RULES, SPECIAL_RULES
+
+    # Build a map of all known rule metadata
+    all_rules_dict = {}
+    for r in RULES:
+        all_rules_dict[r["id"]] = {
+            "id": r["id"],
+            "name": r["name"],
+            "severity": r["severity"],
+            "description": r.get("description", ""),
+        }
+    for r_id, r in SPECIAL_RULES.items():
+        all_rules_dict[r_id] = {
+            "id": r_id,
+            "name": r["name"],
+            "severity": r["severity"],
+            "description": r.get("description", ""),
+        }
+    if custom_rules:
+        for r in custom_rules:
+            all_rules_dict[r["id"]] = {
+                "id": r["id"],
+                "name": r["name"],
+                "severity": r["severity"],
+                "description": r.get("description", ""),
+            }
+
+    # Gather rules mentioned in findings but not in our dictionary
+    for f in findings:
+        r_id = f.get("rule_id")
+        if r_id and r_id not in all_rules_dict:
+            all_rules_dict[r_id] = {
+                "id": r_id,
+                "name": f.get("rule", r_id),
+                "severity": f.get("severity", "medium"),
+                "description": f.get("description", ""),
+            }
+
+    # Map severities to SARIF level configurations
+    severity_map = {
+        "critical": "error",
+        "high": "error",
+        "medium": "warning",
+        "low": "note",
+    }
+
+    # Format the rules array for the SARIF run
+    sarif_rules = []
+    for r_id in sorted(all_rules_dict.keys()):
+        r = all_rules_dict[r_id]
+        level = severity_map.get(r["severity"].lower(), "warning")
+        rule_obj = {
+            "id": r["id"],
+            "name": r["name"],
+            "shortDescription": {"text": r["name"]},
+            "fullDescription": {"text": r["description"] or r["name"]},
+            "defaultConfiguration": {"level": level},
+        }
+        sarif_rules.append(rule_obj)
+
+    # Format the results array
+    sarif_results = []
+    for f in sorted(
+        findings, key=lambda x: (x["path"], x["line"], x.get("rule_id", ""))
+    ):
+        r_id = f.get("rule_id", "generic-secret-key")
+        r_name = f.get("rule", "Generic Secret Key")
+        line = f.get("line", 1)
+        path = f.get("path", "")
+        severity = f.get("severity", "medium")
+
+        # Mask the value if not show_value
+        val = f["value"][:]
+        if not show_value and not f.get("reveal"):
+            val = mask(val)
+
+        msg_text = f"{r_name}: {val}"
+        rel_path = path.replace("\\", "/")
+
+        result_obj = {
+            "ruleId": r_id,
+            "level": severity_map.get(severity.lower(), "warning"),
+            "message": {"text": msg_text},
+            "locations": [
+                {
+                    "physicalLocation": {
+                        "artifactLocation": {"uri": rel_path},
+                        "region": {"startLine": line, "startColumn": 1},
+                    }
+                }
+            ],
+        }
+        sarif_results.append(result_obj)
+
+    sarif_data = {
+        "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+        "version": "2.1.0",
+        "runs": [
+            {
+                "tool": {
+                    "driver": {
+                        "name": "secret-guard",
+                        "version": version,
+                        "rules": sarif_rules,
+                    }
+                },
+                "results": sarif_results,
+            }
+        ],
+    }
+    return json.dumps(sarif_data, indent=2)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -71,6 +71,19 @@ class CliTest(unittest.TestCase):
             self.assertEqual(result.returncode, 1)
             self.assertIsNotNone(__import__("json").loads(result.stdout))
 
+    def test_scan_sarif_emits_parseable_output(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "secret.py").write_text(
+                f"TOKEN = '{SECRET}'", encoding="utf-8"
+            )
+            result = self.run_cli(tmp, "scan", "--sarif", ".")
+            self.assertEqual(result.returncode, 1)
+            sarif_data = json.loads(result.stdout)
+            self.assertEqual(sarif_data["version"], "2.1.0")
+            self.assertEqual(sarif_data["runs"][0]["tool"]["driver"]["name"], "secret-guard")
+            self.assertGreaterEqual(len(sarif_data["runs"][0]["results"]), 1)
+
+
     def test_scan_excludes_extra_directory(self):
         with tempfile.TemporaryDirectory() as tmp:
             Path(tmp, "wip").mkdir()

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -4,7 +4,7 @@ import json
 import re
 import unittest
 
-from secretguard.reporter import format_console, format_json, mask, summarize
+from secretguard.reporter import format_console, format_json, format_sarif, mask, summarize
 
 
 def finding(
@@ -179,6 +179,97 @@ class JsonSchemaTest(unittest.TestCase):
         first = format_json(list(findings), ".")
         second = format_json(list(reversed(findings)), ".")
         self.assertEqual(first, second)
+
+class FormatSarifTest(unittest.TestCase):
+    def test_basic_sarif_structure(self):
+        findings = [
+            {
+                "path": "app.py",
+                "value": "ghp_secretvalue123",
+                "rule": "GitHub Token",
+                "rule_id": "github-token",
+                "severity": "high",
+                "line": 4,
+                "description": "GitHub Personal Access / OAuth token.",
+            }
+        ]
+        sarif_str = format_sarif(findings, "/repo", show_value=False, version="1.2.3")
+        sarif_data = json.loads(sarif_str)
+
+        self.assertEqual(sarif_data["version"], "2.1.0")
+        self.assertIn("$schema", sarif_data)
+        self.assertEqual(len(sarif_data["runs"]), 1)
+
+        run = sarif_data["runs"][0]
+        self.assertEqual(run["tool"]["driver"]["name"], "secret-guard")
+        self.assertEqual(run["tool"]["driver"]["version"], "1.2.3")
+
+        # Verify that all rules are present
+        rules = run["tool"]["driver"]["rules"]
+        self.assertGreater(len(rules), 1)
+        rule_ids = {r["id"] for r in rules}
+        self.assertIn("github-token", rule_ids)
+        self.assertIn("private-key", rule_ids)
+
+        # Verify the findings are correctly reported as results
+        self.assertEqual(len(run["results"]), 1)
+        res = run["results"][0]
+        self.assertEqual(res["ruleId"], "github-token")
+        self.assertEqual(res["level"], "error")
+        self.assertIn("ghp_se", res["message"]["text"])
+        self.assertNotIn("secretvalue", res["message"]["text"])
+
+        # Check locations
+        loc = res["locations"][0]
+        self.assertEqual(loc["physicalLocation"]["artifactLocation"]["uri"], "app.py")
+        self.assertEqual(loc["physicalLocation"]["region"]["startLine"], 4)
+        self.assertEqual(loc["physicalLocation"]["region"]["startColumn"], 1)
+
+    def test_sarif_show_value(self):
+        findings = [
+            {
+                "path": "src/config.py",
+                "value": "ghp_myactualsecret",
+                "rule": "GitHub Token",
+                "rule_id": "github-token",
+                "severity": "high",
+                "line": 10,
+                "description": "GitHub Token",
+            }
+        ]
+        sarif_str = format_sarif(findings, "/repo", show_value=True)
+        sarif_data = json.loads(sarif_str)
+        res = sarif_data["runs"][0]["results"][0]
+        self.assertIn("ghp_myactualsecret", res["message"]["text"])
+
+    def test_sarif_custom_rules_and_unknown(self):
+        findings = [
+            {
+                "path": "app.js",
+                "value": "custom_val",
+                "rule": "My Custom Rule",
+                "rule_id": "my-custom-rule",
+                "severity": "medium",
+                "line": 5,
+                "description": "Custom description",
+            }
+        ]
+        custom_rules = [
+            {
+                "id": "my-custom-rule",
+                "name": "My Custom Rule",
+                "severity": "medium",
+                "description": "Custom description",
+            }
+        ]
+        sarif_str = format_sarif(
+            findings, "/repo", show_value=False, custom_rules=custom_rules
+        )
+        sarif_data = json.loads(sarif_str)
+        rules = sarif_data["runs"][0]["tool"]["driver"]["rules"]
+        rule_ids = {r["id"] for r in rules}
+        self.assertIn("my-custom-rule", rule_ids)
+        self.assertEqual(sarif_data["runs"][0]["results"][0]["level"], "warning")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds a \--sarif\ output format option and a fully compliant SARIF reporter to integrate findings with GitHub Code Scanning (code scanning alerts).