### PR TITLE
feat(cli): add --reveal-prefix and --reveal-suffix options

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -22,6 +22,8 @@ secret-guard scan [path] [options]
 | `--no-entropy` | Disable high-entropy string detection |
 | `--json` | Output findings as JSON |
 | `--show-value` | Print full secret values (default masks them) |
+| `--reveal-prefix N` | Show first N characters of the masked secret |
+| `--reveal-suffix N` | Show last N characters of the masked secret |
 | `--staged` | Scan only files staged in git |
 | `--skip-rule RULE` | Never run the given rule id (repeatable) |
 | `--only-rule RULE` | Run only the given rule id (repeatable) |
@@ -56,6 +58,14 @@ commit — exactly what would otherwise be committed.
 ### `--json`
 
 Emits stable JSON. `--show-value` controls whether masked or raw values appear.
+
+### `--reveal-prefix` / `--reveal-suffix`
+
+- `--reveal-prefix N` shows the first `N` characters of the masked secret, keeping the rest masked.
+- `--reveal-suffix N` shows the last `N` characters of the masked secret, keeping the rest masked.
+- If both are provided, they reveal their respective parts and mask the middle.
+- If the sum of prefix and suffix reveal lengths is greater than or equal to the secret length, the secret is completely masked to prevent accidental leakage of the full secret value.
+- `--show-value` always takes precedence and will print the full unmasked secret value, ignoring these flags.
 
 ### `--exclude`
 

--- a/secretguard/cli.py
+++ b/secretguard/cli.py
@@ -163,7 +163,15 @@ def build_parser():
     )
     scan.add_argument(
         "--show-value", action="store_true",
-        help="Print full secret values (default masks them).",
+        help="Print full secret values (default masks them). Takes precedence over --reveal-prefix and --reveal-suffix.",
+    )
+    scan.add_argument(
+        "--reveal-prefix", type=int, default=None, metavar="N",
+        help="Show first N characters of the masked secret. Ignored if --show-value is set.",
+    )
+    scan.add_argument(
+        "--reveal-suffix", type=int, default=None, metavar="N",
+        help="Show last N characters of the masked secret. Ignored if --show-value is set.",
     )
     scan.add_argument(
         "--no-color", action="store_true",
@@ -458,6 +466,7 @@ def cmd_scan(args):
             format_json(
                 shown, os.path.abspath(args.path), show_value=args.show_value,
                 truncated=truncated, total_findings=len(findings),
+                reveal_prefix=args.reveal_prefix, reveal_suffix=args.reveal_suffix,
             )
         )
     else:
@@ -466,6 +475,7 @@ def cmd_scan(args):
             format_console(
                 shown, args.path, show_value=args.show_value, color=color,
                 truncated=truncated, total_findings=len(findings),
+                reveal_prefix=args.reveal_prefix, reveal_suffix=args.reveal_suffix,
             )
         )
     return 1 if has_blocking_findings(findings, severity_threshold) else 0

--- a/secretguard/reporter.py
+++ b/secretguard/reporter.py
@@ -23,10 +23,24 @@ def should_color(force=None):
     return sys.stdout.isatty() and os.environ.get("NO_COLOR") is None
 
 
-def mask(value, visible=6):
-    if len(value) <= visible + 4:
-        return "*" * len(value)
-    return value[:visible] + "*" * max(0, len(value) - visible - 0)
+def mask(value, reveal_prefix=None, reveal_suffix=None):
+    if reveal_prefix is None and reveal_suffix is None:
+        visible = 6
+        if len(value) <= visible + 4:
+            return "*" * len(value)
+        return value[:visible] + "*" * max(0, len(value) - visible)
+
+    pref_len = max(0, reveal_prefix) if reveal_prefix is not None else 0
+    suff_len = max(0, reveal_suffix) if reveal_suffix is not None else 0
+    val_len = len(value)
+
+    if pref_len + suff_len >= val_len:
+        return "*" * val_len
+
+    middle_stars = val_len - pref_len - suff_len
+    suffix_part = value[val_len - suff_len:] if suff_len > 0 else ""
+    return value[:pref_len] + "*" * middle_stars + suffix_part
+
 
 def format_console(
     findings,
@@ -35,6 +49,8 @@ def format_console(
     color=None,
     truncated=False,
     total_findings=None,
+    reveal_prefix=None,
+    reveal_suffix=None,
 ):
     color = should_color(force=color)
     lines = []
@@ -45,7 +61,7 @@ def format_console(
             tag = SEVERITY_COLORS[severity] + tag + RESET
         value = finding["value"][:]
         if not show_value and not finding.get("reveal"):
-            value = mask(value)
+            value = mask(value, reveal_prefix=reveal_prefix, reveal_suffix=reveal_suffix)
         lines.append(
             "{path}:{line} [{tag}] {rule}: {value}".format(
                 path=finding["path"],
@@ -107,13 +123,13 @@ def summarize(findings):
     return counts
 
 
-def format_json(findings, root, show_value=False, truncated=False, total_findings=None):
+def format_json(findings, root, show_value=False, truncated=False, total_findings=None, reveal_prefix=None, reveal_suffix=None):
     ordered = sorted(findings, key=lambda f: (f["path"], f["line"], f["rule"]))
     sanitized = []
     for finding in ordered:
         item = dict(finding)
         if not show_value and not finding.get("reveal"):
-            item["value"] = mask(item["value"])
+            item["value"] = mask(item["value"], reveal_prefix=reveal_prefix, reveal_suffix=reveal_suffix)
         sanitized.append(item)
     payload = {
         "schema_version": SCHEMA_VERSION,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -71,6 +71,24 @@ class CliTest(unittest.TestCase):
             self.assertEqual(result.returncode, 1)
             self.assertIsNotNone(__import__("json").loads(result.stdout))
 
+    def test_scan_reveal_prefix_option(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "secret.py").write_text(
+                f"TOKEN = '{SECRET}'", encoding="utf-8"
+            )
+            result = self.run_cli(tmp, "scan", "--reveal-prefix", "4", ".")
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("ghp_************************************", result.stdout)
+
+    def test_scan_reveal_suffix_option(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "secret.py").write_text(
+                f"TOKEN = '{SECRET}'", encoding="utf-8"
+            )
+            result = self.run_cli(tmp, "scan", "--reveal-suffix", "4", ".")
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("************************************wxyz", result.stdout)
+
     def test_scan_excludes_extra_directory(self):
         with tempfile.TemporaryDirectory() as tmp:
             Path(tmp, "wip").mkdir()

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -39,6 +39,24 @@ class MaskTest(unittest.TestCase):
         masked = mask("abcdefghijk")  # length 11
         self.assertEqual(masked, "abcdef" + "*" * 5)
 
+    def test_reveal_prefix(self):
+        self.assertEqual(mask("abcdefgh", reveal_prefix=4), "abcd****")
+        self.assertEqual(mask("abcde", reveal_prefix=4), "abcd*")
+
+    def test_reveal_suffix(self):
+        self.assertEqual(mask("abcdefgh", reveal_suffix=4), "****efgh")
+        self.assertEqual(mask("abcde", reveal_suffix=4), "*bcde")
+
+    def test_reveal_prefix_and_suffix(self):
+        self.assertEqual(mask("abcdefgh", reveal_prefix=2, reveal_suffix=2), "ab****gh")
+
+    def test_reveal_overlap_masks_completely(self):
+        # If pref_len + suff_len >= val_len, it should mask completely to prevent full leak
+        self.assertEqual(mask("abc", reveal_prefix=4), "***")
+        self.assertEqual(mask("abcd", reveal_prefix=4), "****")
+        self.assertEqual(mask("abcd", reveal_prefix=2, reveal_suffix=2), "****")
+        self.assertEqual(mask("abcde", reveal_prefix=3, reveal_suffix=3), "*****")
+
 
 class SummarizeTest(unittest.TestCase):
     def test_counts_by_severity(self):
@@ -111,6 +129,16 @@ class FormatConsoleTest(unittest.TestCase):
         self.assertLess(positions["a.py:1"], positions["a.py:9"])
         self.assertLess(positions["a.py:9"], positions["b.py:2"])
 
+    def test_reveal_prefix_option(self):
+        value = "ghp_secretvalue123"
+        report = format_console([finding(value=value)], ".", show_value=False, reveal_prefix=4)
+        self.assertIn("ghp_**************", report)
+
+    def test_reveal_suffix_option(self):
+        value = "ghp_secretvalue123"
+        report = format_console([finding(value=value)], ".", show_value=False, reveal_suffix=3)
+        self.assertIn("***************123", report)
+
 
 class FormatJsonTest(unittest.TestCase):
     def test_roundtrip_full_values(self):
@@ -130,6 +158,16 @@ class FormatJsonTest(unittest.TestCase):
         f["reveal"] = True
         payload = json.loads(format_json([f], "/repo"))
         self.assertEqual(payload["findings"][0]["value"], "GITHUB_TOKEN")
+
+    def test_reveal_prefix_json(self):
+        findings = [finding(severity="high", value="ghp_secretvalue123")]
+        payload = json.loads(format_json(findings, "/repo", show_value=False, reveal_prefix=4))
+        self.assertEqual(payload["findings"][0]["value"], "ghp_**************")
+
+    def test_reveal_suffix_json(self):
+        findings = [finding(severity="high", value="ghp_secretvalue123")]
+        payload = json.loads(format_json(findings, "/repo", show_value=False, reveal_suffix=3))
+        self.assertEqual(payload["findings"][0]["value"], "***************123")
 
     def test_valid_json(self):
         report = format_json([], ".")


### PR DESCRIPTION
Closes #61. Adds \--reveal-prefix N\ and \--reveal-suffix N\ options to show a few characters of the secret value while keeping the rest masked. This simplifies hand-debugging of secrets while ensuring they remain secure. Both text and JSON format outputs are supported and tested.