### PR TITLE
feat: support max_findings in secret-guard.json config

### DIFF
--- a/secretguard/cli.py
+++ b/secretguard/cli.py
@@ -70,6 +70,7 @@ KNOWN_CONFIG_KEYS = {
     "rules",
     "baseline",
     "severity",
+    "max_findings",
 }
 
 
@@ -134,6 +135,13 @@ def load_config(config_path):
         _config_fatal(
             f"Error: 'severity' in {config_path} must be one of: "
             "low, medium, high, critical."
+        )
+    if "max_findings" in data and (
+        not isinstance(data["max_findings"], int)
+        or data["max_findings"] < 1
+    ):
+        _config_fatal(
+            f"Error: 'max_findings' in {config_path} must be a positive integer."
         )
     return data
 
@@ -447,6 +455,8 @@ def cmd_scan(args):
     findings = filter_baseline(findings, baseline)
 
     max_findings = getattr(args, "max_findings", None)
+    if max_findings is None:
+        max_findings = config.get("max_findings")
     truncated = False
     shown = findings
     if max_findings is not None and len(findings) > max_findings:
@@ -490,6 +500,7 @@ def cmd_init(args):
         "skip_rules": [],
         "only_rules": [],
         "rules": [],
+        "max_findings": None,
     }
 
     try:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -248,6 +248,7 @@ class CliTest(unittest.TestCase):
             data = json.loads(content)
             self.assertIn("exclude", data)
             self.assertIn("//", data)
+            self.assertIn("max_findings", data)
 
     def test_init_errors_if_file_exists(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -406,6 +407,41 @@ class CliTest(unittest.TestCase):
             result = self.run_cli(tmp, "scan", ".")
             self.assertEqual(result.returncode, 2)
             self.assertIn("Error: 'severity' in", result.stderr)
+
+    def test_scan_max_findings_config_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "secret.py").write_text(
+                f"TOKEN = '{SECRET}'\n", encoding="utf-8"
+            )
+            Path(tmp, "secret2.py").write_text(
+                f"TOKEN = '{SECRET}'\n", encoding="utf-8"
+            )
+            config_file = Path(tmp, "secret-guard.json")
+            config_content = {"max_findings": 1}
+            config_file.write_text(json.dumps(config_content), encoding="utf-8")
+
+            result = self.run_cli(tmp, "scan", "--json", ".")
+            self.assertEqual(result.returncode, 1)
+            payload = json.loads(result.stdout)
+            self.assertTrue(payload.get("truncated"))
+            self.assertGreater(payload.get("total_findings"), 1)
+            self.assertEqual(len(payload["findings"]), 1)
+
+            result_override = self.run_cli(
+                tmp, "scan", "--max-findings", "100", "."
+            )
+            self.assertEqual(result_override.returncode, 1)
+            self.assertNotIn("truncated", result_override.stdout)
+
+    def test_scan_max_findings_config_validation(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            config_file = Path(tmp, "secret-guard.json")
+            config_content = {"max_findings": "many"}
+            config_file.write_text(json.dumps(config_content), encoding="utf-8")
+
+            result = self.run_cli(tmp, "scan", ".")
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("Error: 'max_findings' in", result.stderr)
 
     def test_stdin_scan_detects_secret(self):
         result = subprocess.run(


### PR DESCRIPTION
## Summary

Adds support for `max_findings` in the `secret-guard.json` configuration file, so teams can cap reported findings from a checked-in config instead of only via the CLI `--max-findings` flag.

## Changes

- **`secretguard/cli.py`**
  - Registered `max_findings` as a known configuration key.
  - Added validation: `max_findings` must be a positive integer (exit code `2` with an actionable message otherwise).
  - `cmd_scan` now falls back to the config value when `--max-findings` is not passed (CLI flags still take precedence).
  - `secret-guard init` now scaffolds a starter config that includes `max_findings`.
- **`tests/test_cli.py`**
  - Added a test verifying config-driven truncation and CLI override precedence.
  - Added a test verifying invalid `max_findings` config values fail with exit code `2`.
  - Updated the `init` scaffold test to assert the key is present.

## Validation

- Full test suite passes (165 tests).
- `ruff check secretguard tests` passes.
- Self-scan clean (no secrets introduced).
