### PR TITLE
feat(cli): add --quiet flag to suppress scan output

### DIFF
--- a/secretguard/cli.py
+++ b/secretguard/cli.py
@@ -199,6 +199,10 @@ def build_parser():
         help="Disable colored console output.",
     )
     scan.add_argument(
+        "--quiet", action="store_true",
+        help="Suppress all scan output; only the exit code is set.",
+    )
+    scan.add_argument(
         "--staged", action="store_true",
         help="Scan only files staged in git.",
     )
@@ -484,31 +488,35 @@ def cmd_scan(args):
         truncated = True
         shown = findings[:max_findings]
 
-    if args.csv:
-        print(
-            format_csv(
-                shown, os.path.abspath(args.path), show_value=args.show_value,
-                truncated=truncated, total_findings=len(findings),
-                reveal_prefix=args.reveal_prefix, reveal_suffix=args.reveal_suffix,
+    if not args.quiet:
+        if args.csv:
+            print(
+                format_csv(
+                    shown, os.path.abspath(args.path), show_value=args.show_value,
+                    truncated=truncated, total_findings=len(findings),
+                    reveal_prefix=args.reveal_prefix,
+                    reveal_suffix=args.reveal_suffix,
+                )
             )
-        )
-    elif args.json:
-        print(
-            format_json(
-                shown, os.path.abspath(args.path), show_value=args.show_value,
-                truncated=truncated, total_findings=len(findings),
-                reveal_prefix=args.reveal_prefix, reveal_suffix=args.reveal_suffix,
+        elif args.json:
+            print(
+                format_json(
+                    shown, os.path.abspath(args.path), show_value=args.show_value,
+                    truncated=truncated, total_findings=len(findings),
+                    reveal_prefix=args.reveal_prefix,
+                    reveal_suffix=args.reveal_suffix,
+                )
             )
-        )
-    else:
-        color = False if args.no_color else None
-        print(
-            format_console(
-                shown, args.path, show_value=args.show_value, color=color,
-                truncated=truncated, total_findings=len(findings),
-                reveal_prefix=args.reveal_prefix, reveal_suffix=args.reveal_suffix,
+        else:
+            color = False if args.no_color else None
+            print(
+                format_console(
+                    shown, args.path, show_value=args.show_value, color=color,
+                    truncated=truncated, total_findings=len(findings),
+                    reveal_prefix=args.reveal_prefix,
+                    reveal_suffix=args.reveal_suffix,
+                )
             )
-        )
     return 1 if has_blocking_findings(findings, severity_threshold) else 0
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -192,6 +192,32 @@ class CliTest(unittest.TestCase):
             self.assertNotEqual(result.returncode, 0)
             self.assertIn("not allowed with argument", result.stderr)
 
+    def test_scan_quiet_suppresses_output_but_sets_exit_code(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "secret.py").write_text(
+                f"TOKEN = '{SECRET}'", encoding="utf-8"
+            )
+            result = self.run_cli(tmp, "scan", "--quiet", ".")
+            self.assertEqual(result.returncode, 1)
+            self.assertEqual(result.stdout, "")
+            self.assertEqual(result.stderr, "")
+
+    def test_scan_quiet_clean_returns_zero_with_no_output(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "main.py").write_text("print('clean')\n", encoding="utf-8")
+            result = self.run_cli(tmp, "scan", "--quiet", ".")
+            self.assertEqual(result.returncode, 0)
+            self.assertEqual(result.stdout, "")
+
+    def test_scan_quiet_with_json_suppresses_output(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "secret.py").write_text(
+                f"TOKEN = '{SECRET}'", encoding="utf-8"
+            )
+            result = self.run_cli(tmp, "scan", "--quiet", "--json", ".")
+            self.assertEqual(result.returncode, 1)
+            self.assertEqual(result.stdout, "")
+
     def test_help_lists_commands(self):
         result = self.run_cli(str(PROJECT_ROOT), "--help")
         self.assertEqual(result.returncode, 0)


### PR DESCRIPTION
## Summary

Adds a --quiet flag to secret-guard scan that suppresses all scan output while preserving the exit status.

## Why

Useful for CI gating and scripting where you only want the exit code (0 = clean, 1 = secrets found) and don't want to parse or echo the report.

## Changes

- secretguard/cli.py: add --quiet argument; skip printing the report/findings/summary while still returning the correct exit code.
- tests/test_cli.py: tests for exit code + no stdout (with secret, when clean, and combined with --json).

## Verification

- 191 tests pass
- ruff clean