### PR TITLE
feat(cli): allow scanning multiple paths with secret-guard scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ secret-guard scan
 # Scan a specific path
 secret-guard scan ./src
 
+# Scan several files and directories at once
+secret-guard scan ./src ./tests config.py
+
 # JSON output for CI and tooling
 secret-guard scan --json
 
@@ -157,17 +160,20 @@ docker run --rm -v "${PWD}:/code" ghcr.io/taksh1507/secret-guard:latest scan /co
 ## Usage
 
 ```
-secret-guard scan [path] [options]
+secret-guard scan [paths...] [options]
 
 positional arguments:
-  path                Path to scan (default: .)
+  paths               Files or directories to scan (default: .). Repeatable
+                      (e.g. `secret-guard scan src/ tests/ config.py`).
 
 options:
   --exclude DIR       Additional directory names to skip (repeatable)
   --no-entropy        Disable high-entropy string detection
   --json              Output findings as JSON
+  --csv               Output findings as CSV
   --show-value        Print full secret values (default masks them)
   --no-color          Disable colored console output
+  --quiet             Suppress all scan output; only the exit code is set
   --staged            Scan only files staged in git
   --baseline FILE     Suppress findings listed in a baseline file
   --severity LEVEL    Minimum severity to fail the scan (low, medium, high, critical)

--- a/secretguard/cli.py
+++ b/secretguard/cli.py
@@ -157,7 +157,10 @@ def build_parser():
     scan = subparsers.add_parser(
         "scan", help="Scan files for secrets."
     )
-    scan.add_argument("path", nargs="?", default=".", help="Path to scan (default: .)")
+    scan.add_argument(
+        "paths", nargs="*", default=["."], metavar="PATH",
+        help="Files or directories to scan (default: .).",
+    )
     scan.add_argument(
         "--exclude", action="append", default=[],
         metavar="DIR", help="Additional directory names to skip (repeatable).",
@@ -379,9 +382,9 @@ def _scan_staged(exclude, skip_rules, only_rules, custom_rules):
     return findings
 
 
-def _scan_path(args, exclude, skip_rules, only_rules, no_entropy, custom_rules):
+def _scan_path(path, exclude, skip_rules, only_rules, no_entropy, custom_rules):
     scanner = Scanner(
-        args.path, excludes=exclude, skip_rules=skip_rules, only_rules=only_rules,
+        path, excludes=exclude, skip_rules=skip_rules, only_rules=only_rules,
         custom_rules=custom_rules,
     )
     scanner.include_entropy = not no_entropy
@@ -395,9 +398,18 @@ def _run_scan(args, exclude, skip_rules, only_rules, no_entropy, custom_rules):
         )
     if args.staged:
         return _scan_staged(exclude, skip_rules, only_rules, custom_rules)
-    return _scan_path(
-        args, exclude, skip_rules, only_rules, no_entropy, custom_rules
-    )
+    multi = len(args.paths) > 1
+    findings = []
+    for path in args.paths:
+        for finding in _scan_path(
+            path, exclude, skip_rules, only_rules, no_entropy, custom_rules
+        ):
+            if multi:
+                finding["path"] = os.path.join(
+                    path, finding["path"]
+                ).replace(os.sep, "/")
+            findings.append(finding)
+    return findings
 
 def has_blocking_findings(findings, severity_threshold):
     """Return True if any finding meets or exceeds the severity threshold."""
@@ -434,7 +446,7 @@ def _load_custom_rules(args, config, config_file):
 
 
 def cmd_scan(args):
-    scan_path = "." if args.staged else args.path
+    scan_path = "." if (args.staged or args.stdin) else args.paths[0]
     config_file = find_config(scan_path)
     config = {}
     if config_file:
@@ -488,11 +500,17 @@ def cmd_scan(args):
         truncated = True
         shown = findings[:max_findings]
 
+    root = (
+        os.path.abspath(args.paths[0])
+        if len(args.paths) == 1
+        else os.getcwd()
+    )
+
     if not args.quiet:
         if args.csv:
             print(
                 format_csv(
-                    shown, os.path.abspath(args.path), show_value=args.show_value,
+                    shown, root, show_value=args.show_value,
                     truncated=truncated, total_findings=len(findings),
                     reveal_prefix=args.reveal_prefix,
                     reveal_suffix=args.reveal_suffix,
@@ -501,7 +519,7 @@ def cmd_scan(args):
         elif args.json:
             print(
                 format_json(
-                    shown, os.path.abspath(args.path), show_value=args.show_value,
+                    shown, root, show_value=args.show_value,
                     truncated=truncated, total_findings=len(findings),
                     reveal_prefix=args.reveal_prefix,
                     reveal_suffix=args.reveal_suffix,
@@ -511,7 +529,7 @@ def cmd_scan(args):
             color = False if args.no_color else None
             print(
                 format_console(
-                    shown, args.path, show_value=args.show_value, color=color,
+                    shown, root, show_value=args.show_value, color=color,
                     truncated=truncated, total_findings=len(findings),
                     reveal_prefix=args.reveal_prefix,
                     reveal_suffix=args.reveal_suffix,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -218,6 +218,55 @@ class CliTest(unittest.TestCase):
             self.assertEqual(result.returncode, 1)
             self.assertEqual(result.stdout, "")
 
+    def test_scan_multiple_paths_aggregates_findings(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            a = Path(tmp, "a")
+            b = Path(tmp, "b")
+            a.mkdir()
+            b.mkdir()
+            Path(a, "secret.py").write_text(
+                f"TOKEN = '{SECRET}'", encoding="utf-8"
+            )
+            Path(b, "secret2.py").write_text(
+                f"TOKEN = '{SECRET}'", encoding="utf-8"
+            )
+            result = self.run_cli(tmp, "scan", "--json", "a", "b")
+            self.assertEqual(result.returncode, 1)
+            payload = json.loads(result.stdout)
+            paths = {f["path"] for f in payload["findings"]}
+            self.assertIn("a/secret.py", paths)
+            self.assertIn("b/secret2.py", paths)
+
+    def test_scan_multiple_paths_mixed_clean_and_dirty(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            clean = Path(tmp, "clean")
+            dirty = Path(tmp, "dirty")
+            clean.mkdir()
+            dirty.mkdir()
+            Path(clean, "main.py").write_text("print('ok')\n", encoding="utf-8")
+            Path(dirty, "secret.py").write_text(
+                "password = 'somepassword'", encoding="utf-8"
+            )
+            result = self.run_cli(
+                tmp, "scan", "--only-rule", "credential-assignment",
+                "clean", "dirty",
+            )
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("dirty/secret.py", result.stdout)
+            self.assertNotIn("clean/main.py", result.stdout)
+
+    def test_scan_multiple_paths_all_clean_returns_zero(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            a = Path(tmp, "a")
+            b = Path(tmp, "b")
+            a.mkdir()
+            b.mkdir()
+            Path(a, "main.py").write_text("print('ok')\n", encoding="utf-8")
+            Path(b, "main.py").write_text("print('ok')\n", encoding="utf-8")
+            result = self.run_cli(tmp, "scan", "a", "b")
+            self.assertEqual(result.returncode, 0)
+            self.assertIn("0 total", result.stdout)
+
     def test_help_lists_commands(self):
         result = self.run_cli(str(PROJECT_ROOT), "--help")
         self.assertEqual(result.returncode, 0)


### PR DESCRIPTION
## Summary

`secret-guard scan` now accepts **zero or more** files/directories and aggregates findings across all of them.

## Why

Single-path scans forced users to run the tool once per directory, or they lacked an easy way to scan a few specific files. This lets you scan several paths in one invocation.

## Changes

- `secretguard/cli.py`:
  - scan positional arg is now `paths` (`nargs='*'`, default `['.']`)
  - `_run_scan` loops over every path and merges findings; in multi-path mode each finding's path is prefixed with the source path so output is unambiguous (e.g. `a/secret.py`, `b/secret2.py`)
  - the report `root` resolves to the single path or the working directory
- `tests/test_cli.py`: aggregated findings, mixed clean/dirty, and all-clean multi-path cases
- `README.md`: updated usage + example for multiple paths; added `--csv` / `--quiet` to the options list

## Example

```bash
secret-guard scan ./src ./tests config.py
```

## Verification

- 194 tests pass
- ruff clean
