### PR TITLE
feat(cli): add --summary output mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ options:
   --no-entropy        Disable high-entropy string detection
   --json              Output findings as JSON
   --csv               Output findings as CSV
+  --summary           Print only the severity summary instead of the
+                      detailed report
   --show-value        Print full secret values (default masks them)
   --no-color          Disable colored console output
   --quiet             Suppress all scan output; only the exit code is set

--- a/secretguard/cli.py
+++ b/secretguard/cli.py
@@ -8,7 +8,12 @@ import subprocess
 import sys
 
 from . import __version__
-from .reporter import format_console, format_csv, format_json
+from .reporter import (
+    format_console,
+    format_csv,
+    format_json,
+    format_summary,
+)
 from .rules import (
     RULES,
     SPECIAL_RULES,
@@ -175,6 +180,10 @@ def build_parser():
     )
     out_group.add_argument(
         "--csv", action="store_true", help="Output CSV instead of a report.",
+    )
+    out_group.add_argument(
+        "--summary", action="store_true",
+        help="Print only the severity summary instead of the full report.",
     )
     scan.add_argument(
         "--show-value", action="store_true",
@@ -507,7 +516,17 @@ def cmd_scan(args):
     )
 
     if not args.quiet:
-        if args.csv:
+        if args.summary:
+            color = False if args.no_color else None
+            print(
+                format_summary(
+                    shown, root, show_value=args.show_value, color=color,
+                    truncated=truncated, total_findings=len(findings),
+                    reveal_prefix=args.reveal_prefix,
+                    reveal_suffix=args.reveal_suffix,
+                )
+            )
+        elif args.csv:
             print(
                 format_csv(
                     shown, root, show_value=args.show_value,

--- a/secretguard/reporter.py
+++ b/secretguard/reporter.py
@@ -117,6 +117,61 @@ def format_console(
     return "\n".join(lines)
 
 
+def format_summary(
+    findings,
+    root,
+    show_value=True,
+    color=None,
+    truncated=False,
+    total_findings=None,
+    reveal_prefix=None,
+    reveal_suffix=None,
+):
+    """Render only the concise severity summary, omitting per-finding lines.
+
+    Useful for CI logs where the full report is noise but an aggregate count
+    is still wanted. Mirrors the trailing summary line of format_console.
+    """
+
+    color = should_color(force=color)
+    summary = summarize(findings)
+    if truncated:
+        summary["truncated"] = total_findings - len(findings)
+        summary_line = (
+            "{critical} critical, {high} high, {medium} medium, {low} low — "
+            "{total} total (showing {shown} of {total_findings}; "
+            "{truncated} truncated)"
+        ).format(
+            critical=summary["critical"],
+            high=summary["high"],
+            medium=summary["medium"],
+            low=summary["low"],
+            total=summary["total"],
+            shown=len(findings),
+            total_findings=total_findings,
+            truncated=summary["truncated"],
+        )
+    else:
+        summary_line = (
+            "{critical} critical, {high} high, {medium} medium, {low} low — "
+            "{total} total"
+        ).format(
+            critical=summary["critical"],
+            high=summary["high"],
+            medium=summary["medium"],
+            low=summary["low"],
+            total=summary["total"],
+        )
+    if color:
+        summary_line = (
+            "\033[31m{critical}\033[0m critical, "
+            "\033[31m{high}\033[0m high, "
+            "\033[33m{medium}\033[0m medium, "
+            "\033[36m{low}\033[0m low — {total} total"
+        ).format(**summary)
+    return summary_line
+
+
 def summarize(findings):
     total = len(findings)
     counts = {"critical": 0, "high": 0, "medium": 0, "low": 0}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -176,6 +176,34 @@ class CliTest(unittest.TestCase):
             self.assertEqual(result.returncode, 1)
             self.assertNotIn(SECRET, result.stdout)
 
+    def test_scan_summary_emits_counts_only(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "secret.py").write_text(
+                f"TOKEN = '{SECRET}'", encoding="utf-8"
+            )
+            result = self.run_cli(tmp, "scan", "--summary", ".")
+            self.assertEqual(result.returncode, 1)
+            self.assertNotIn(SECRET, result.stdout)
+            self.assertEqual(
+                result.stdout.count("\n"), 1  # single summary line
+            )
+            self.assertIn("total", result.stdout)
+            self.assertNotIn("secret.py", result.stdout)
+
+    def test_scan_summary_clean_prints_zero_counts(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "main.py").write_text("print('clean')\n", encoding="utf-8")
+            result = self.run_cli(tmp, "scan", "--summary", ".")
+            self.assertEqual(result.returncode, 0)
+            self.assertIn("0 total", result.stdout)
+
+    def test_scan_summary_and_json_are_mutually_exclusive(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "main.py").write_text("print('clean')\n", encoding="utf-8")
+            result = self.run_cli(tmp, "scan", "--summary", "--json", ".")
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("not allowed with argument", result.stderr)
+
     def test_scan_csv_show_value_exposes_full_value(self):
         with tempfile.TemporaryDirectory() as tmp:
             Path(tmp, "secret.py").write_text(

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -10,6 +10,7 @@ from secretguard.reporter import (
     format_console,
     format_csv,
     format_json,
+    format_summary,
     mask,
     summarize,
 )
@@ -89,6 +90,48 @@ class SummarizeTest(unittest.TestCase):
         self.assertEqual(
             sum(summary[k] for k in ("critical", "high", "medium", "low")), 0
         )
+
+
+class FormatSummaryTest(unittest.TestCase):
+    def test_clean_prints_zero_counts(self):
+        line = format_summary([], ".", color=False)
+        self.assertEqual(line, "0 critical, 0 high, 0 medium, 0 low — 0 total")
+
+    def test_counts_by_severity(self):
+        findings = [
+            finding(severity="critical"),
+            finding(severity="high", value="abcd1234"),
+            finding(severity="medium", value="abcdef12"),
+            finding(severity="low", value="a"),
+        ]
+        line = format_summary(findings, ".", color=False)
+        self.assertEqual(
+            line, "1 critical, 1 high, 1 medium, 1 low — 4 total"
+        )
+
+    def test_masks_values(self):
+        line = format_summary(
+            [finding(value="ghp_supersecret")], ".", color=False
+        )
+        self.assertNotIn("ghp_supersecret", line)
+
+    def test_color_true_when_requested(self):
+        line = format_summary([finding()], ".", color=True)
+        self.assertIn("\033[", line)
+
+    def test_color_false_is_plain(self):
+        line = format_summary([finding()], ".", color=False)
+        self.assertNotIn("\033[", line)
+
+    def test_truncated_reports_totals(self):
+        findings = [
+            finding(severity="high"),
+            finding(severity="high", value="abcd1234"),
+        ]
+        line = format_summary(
+            findings, ".", color=False, truncated=True, total_findings=5
+        )
+        self.assertIn("2 total (showing 2 of 5; 3 truncated)", line)
 
 
 class FormatConsoleTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

Adds a new `--summary` output mode for `secret-guard scan` that prints **only**
the concise severity summary line (e.g. `2 critical, 1 high, 0 medium, 0 low — 3 total`)
instead of the full per-finding report.

This complements the existing `--json` and `--csv` formats and is handy for CI
logs where the full report is noise but an aggregate count is still wanted.

## Changes

- `secretguard/reporter.py`: add `format_summary()` reusing the existing
  `summarize()` helper; mirrors the trailing summary line of `format_console()`,
  including `--max-findings` truncated-total reporting and `--no-color` support.
- `secretguard/cli.py`: add `--summary` to the mutually-exclusive
  `--json` / `--csv` output group and route output in `cmd_scan`.
- `tests/test_reporter.py`: `FormatSummaryTest` covering clean/findings counts,
  value masking, color on/off, and truncated totals.
- `tests/test_cli.py`: tests for `--summary` single-line output, clean-zero
  counts, and mutual exclusion with `--json`.
- `README.md`: document the `--summary` option.

## Checks

- `pytest` — 203 passed
- `ruff check` — all passed
