### PR TITLE
feat(rules): detect Bearer tokens and generic sk- prefixed secret keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ and dozens of other secrets — before they reach your repository history.
 
 ## Overview
 
-secret-guard scans source files for hardcoded credentials using **30 regex
+secret-guard scans source files for hardcoded credentials using **32 regex
 rules** combined with **Shannon-entropy detection**, and reports each finding
 with a severity level and a **masked** value. By default, secret values are
 never printed.
@@ -28,10 +28,10 @@ never printed.
 | Category | Detection rules |
 | --- | --- |
 | Cloud / SaaS | AWS Access Key IDs, AWS temporary/assigned keys, AWS dashed keys, Google API Keys, Stripe secret keys, SendGrid and Twilio API keys |
-| Tokens | GitHub PATs (classic and fine-grained), Slack tokens and webhooks, OpenAI, Anthropic, Discord, Square, HubSpot, GitLab, Hugging Face, npm, PyPI, DigitalOcean tokens |
+| Tokens | GitHub PATs (classic and fine-grained), Slack tokens and webhooks, OpenAI, Anthropic, Discord, Square, HubSpot, GitLab, Hugging Face, npm, PyPI, DigitalOcean tokens, OAuth2/Auth bearer tokens |
 | Databases | PostgreSQL and MongoDB connection URIs with embedded credentials |
 | Key material | RSA / EC / DSA / OpenSSH / PGP private keys (`critical` severity) |
-| Heuristics | Generic secret keys, credential assignments, JWT tokens, high-entropy strings |
+| Heuristics | Generic secret keys (including `sk-` prefixed keys), credential assignments, JWT tokens, high-entropy strings |
 
 In addition to pattern matching, secret-guard identifies **`.env` files** that
 assign values to secret-looking variable names (`.env`, `.env.local`,

--- a/secretguard/rules.py
+++ b/secretguard/rules.py
@@ -209,6 +209,18 @@ RULES = [
         description="JSON Web Token.",
     ),
     _r(
+        r"(?i)\bbearer[ :][ \t]*[A-Za-z0-9._~+/=-]{20,}\b",
+        "Bearer Token",
+        severity="high",
+        description="OAuth2 / HTTP Authorization bearer token.",
+    ),
+    _r(
+        r"(?i)\bsk-[A-Za-z0-9_-]{20,}",
+        "Generic Secret Key (sk-)",
+        severity="high",
+        description="Suspicious sk- prefixed secret key.",
+    ),
+    _r(
         r"(?i)sq0atp-[0-9A-Za-z_-]{22,}",
         "Square Access Token",
         severity="high",

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -255,6 +255,26 @@ class RuleDetectionTest(unittest.TestCase):
         )
         self.assertIn("JWT Token", rule_names(text))
 
+    def test_jwt_non_json_three_part_not_flagged(self):
+        self.assertNotIn("JWT Token", rule_names("aaa.bbb.ccc"))
+
+    def test_bearer_token(self):
+        text = "Authorization: Bearer abcdefghijklmnopqrstuvwxyz1234567890"
+        self.assertIn("Bearer Token", rule_names(text))
+
+    def test_bearer_token_with_colon(self):
+        text = "credentials = 'Bearer: abcdefghijklmnopqrstuvwxyz123456789012'"
+        self.assertIn("Bearer Token", rule_names(text))
+
+    def test_bearer_short_word_not_flagged(self):
+        self.assertNotIn("Bearer Token", rule_names("Authorization: Bearer hellothere"))
+
+    def test_generic_secret_key_sk_prefix(self):
+        self.assertIn(
+            "Generic Secret Key (sk-)",
+            rule_names("token = sk-nonhexSecretValue1234567890"),
+        )
+
     def test_square_access_token(self):
         self.assertIn(
             "Square Access Token",


### PR DESCRIPTION
## Summary

Addresses #55 — detects JWT and Bearer token formats.

JWTs were already covered by the existing `jwt-token` rule, so this PR closes
the remaining gap: a generic **Bearer / `sk-` prefix** rule with healthy
entropy/limits on false positives.

## Changes

- **`secretguard/rules.py`** — add two regex rules:
  - `Bearer Token` — matches `Authorization: Bearer <token>` / `Bearer <token>`
    / `Bearer: <token>` headers where the token is 20+ chars, so short English
    words (e.g. `Bearer hellothere`) are not flagged.
  - `Generic Secret Key (sk-)` — catches `sk-` prefixed secret keys that are
    not purely hex (the existing `Generic Secret Key` rule only matches hex),
    complementing the OpenAI / Anthropic / Stripe `sk-` rules.
- **`tests/test_rules.py`** — cover the new rules plus the acceptance-criteria
  false-positive cases:
  - real JWT detected (existing), non-JSON 3-part strings (`aaa.bbb.ccc`) not
    flagged
  - `Bearer <long token>` and `Bearer: <token>` detected
  - short `Bearer hellothere` not flagged
  - `sk-` prefixed non-hex key detected
- **`README.md`** — rule count 30 → 32, add OAuth2/Auth bearer tokens to the
  Tokens row and `sk-` prefixed keys to the Heuristics row.

## Acceptance criteria

- [x] Real JWTs (including a valid fixture) are detected.
- [x] Non-JSON 3-part strings are not flagged.
- [x] Entropy-like false positives are kept low (short/non-secret words after
      `Bearer` are ignored; `sk-` prefix requires 20+ chars).

## Checks

- `pytest` — 208 passed
- `ruff check` — all passed

Closes #55