### PR TITLE
feat(report): add XML and HTML report output formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,10 @@ options:
   --csv               Output findings as CSV
   --summary           Print only the severity summary instead of the
                       detailed report
+  --xml               Output findings as a JUnit-style XML report
+  --html              Output findings as a self-contained HTML report
+  --format FMT        Output format: text, json, csv, summary, xml, or html
+                      (aliases: --json, --csv, --summary, --xml, --html)
   --show-value        Print full secret values (default masks them)
   --no-color          Disable colored console output
   --quiet             Suppress all scan output; only the exit code is set

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -21,6 +21,11 @@ secret-guard scan [path] [options]
 | `--exclude DIR` | Skip additional directory names (repeatable) |
 | `--no-entropy` | Disable high-entropy string detection |
 | `--json` | Output findings as JSON |
+| `--csv` | Output findings as CSV |
+| `--summary` | Print only the severity summary instead of the full report |
+| `--xml` | Output findings as a JUnit-style XML report |
+| `--html` | Output findings as a self-contained HTML report |
+| `--format FMT` | Output format: `text`, `json`, `csv`, `summary`, `xml`, or `html` |
 | `--show-value` | Print full secret values (default masks them) |
 | `--reveal-prefix N` | Show first N characters of the masked secret |
 | `--reveal-suffix N` | Show last N characters of the masked secret |
@@ -58,6 +63,31 @@ commit — exactly what would otherwise be committed.
 ### `--json`
 
 Emits stable JSON. `--show-value` controls whether masked or raw values appear.
+
+### `--xml`
+
+Emits a JUnit-style XML report — each finding is a failing `<testcase>` whose
+attributes carry every finding field. Well-suited for CI dashboards that parse
+JUnit XML.
+
+### `--html`
+
+Emits a self-contained HTML report with all styles inlined, so it can be
+saved, emailed, or hosted as-is. Shows a severity summary and one table row
+per finding.
+
+### `--format`
+
+Selects the output format by name. It is an alias for the dedicated flags:
+
+```bash
+secret-guard scan . --format html    # same as --html
+secret-guard scan . --format xml     # same as --xml
+secret-guard scan . --format json    # same as --json
+```
+
+All output formats mask secret values by default; `--show-value` opts in to
+raw values.
 
 ### `--reveal-prefix` / `--reveal-suffix`
 

--- a/secretguard/cli.py
+++ b/secretguard/cli.py
@@ -11,8 +11,10 @@ from . import __version__
 from .reporter import (
     format_console,
     format_csv,
+    format_html,
     format_json,
     format_summary,
+    format_xml,
 )
 from .rules import (
     RULES,
@@ -184,6 +186,20 @@ def build_parser():
     out_group.add_argument(
         "--summary", action="store_true",
         help="Print only the severity summary instead of the full report.",
+    )
+    out_group.add_argument(
+        "--xml", action="store_true",
+        help="Output a JUnit-style XML report instead of a console report.",
+    )
+    out_group.add_argument(
+        "--html", action="store_true",
+        help="Output a self-contained HTML report instead of a console report.",
+    )
+    out_group.add_argument(
+        "--format", choices=("text", "json", "csv", "summary", "xml", "html"),
+        default=None, metavar="FMT",
+        help="Output format: text, json, csv, summary, xml, or html "
+             "(aliases: --json, --csv, --summary, --xml, --html).",
     )
     scan.add_argument(
         "--show-value", action="store_true",
@@ -454,6 +470,45 @@ def _load_custom_rules(args, config, config_file):
     return custom
 
 
+def _output_format(args):
+    """Resolve the active output format from --format or the format flags."""
+
+    if args.format is not None:
+        return args.format
+    for flag in ("json", "csv", "summary", "xml", "html"):
+        if getattr(args, flag, False):
+            return flag
+    return "text"
+
+
+def _render_output(args, findings, shown, root, truncated):
+    """Print findings in the selected output format, honoring --quiet."""
+
+    if args.quiet:
+        return
+    kwargs = dict(
+        show_value=args.show_value,
+        truncated=truncated,
+        total_findings=len(findings),
+        reveal_prefix=args.reveal_prefix,
+        reveal_suffix=args.reveal_suffix,
+    )
+    color = False if args.no_color else None
+    out_format = _output_format(args)
+    if out_format == "summary":
+        print(format_summary(shown, root, color=color, **kwargs))
+    elif out_format == "csv":
+        print(format_csv(shown, root, **kwargs))
+    elif out_format == "json":
+        print(format_json(shown, root, **kwargs))
+    elif out_format == "xml":
+        print(format_xml(shown, root, **kwargs))
+    elif out_format == "html":
+        print(format_html(shown, root, **kwargs))
+    else:
+        print(format_console(shown, root, color=color, **kwargs))
+
+
 def cmd_scan(args):
     scan_path = "." if (args.staged or args.stdin) else args.paths[0]
     config_file = find_config(scan_path)
@@ -515,45 +570,7 @@ def cmd_scan(args):
         else os.getcwd()
     )
 
-    if not args.quiet:
-        if args.summary:
-            color = False if args.no_color else None
-            print(
-                format_summary(
-                    shown, root, show_value=args.show_value, color=color,
-                    truncated=truncated, total_findings=len(findings),
-                    reveal_prefix=args.reveal_prefix,
-                    reveal_suffix=args.reveal_suffix,
-                )
-            )
-        elif args.csv:
-            print(
-                format_csv(
-                    shown, root, show_value=args.show_value,
-                    truncated=truncated, total_findings=len(findings),
-                    reveal_prefix=args.reveal_prefix,
-                    reveal_suffix=args.reveal_suffix,
-                )
-            )
-        elif args.json:
-            print(
-                format_json(
-                    shown, root, show_value=args.show_value,
-                    truncated=truncated, total_findings=len(findings),
-                    reveal_prefix=args.reveal_prefix,
-                    reveal_suffix=args.reveal_suffix,
-                )
-            )
-        else:
-            color = False if args.no_color else None
-            print(
-                format_console(
-                    shown, root, show_value=args.show_value, color=color,
-                    truncated=truncated, total_findings=len(findings),
-                    reveal_prefix=args.reveal_prefix,
-                    reveal_suffix=args.reveal_suffix,
-                )
-            )
+    _render_output(args, findings, shown, root, truncated)
     return 1 if has_blocking_findings(findings, severity_threshold) else 0
 
 

--- a/secretguard/reporter.py
+++ b/secretguard/reporter.py
@@ -1,10 +1,12 @@
-"""Console, JSON, and CSV reporting for findings."""
+"""Console, JSON, CSV, XML, and HTML reporting for findings."""
 
 import csv
+import html
 import io
 import json
 import os
 import sys
+import xml.etree.ElementTree as ET
 
 SEVERITY_COLORS = {
     "critical": "\033[31;1m",  # bright red
@@ -258,3 +260,178 @@ def format_csv(
             ]
         )
     return buf.getvalue()
+
+
+def _masked_value(finding, show_value, reveal_prefix, reveal_suffix):
+    """The value to emit for a finding, masked unless revealed."""
+    value = finding["value"][:]
+    if not show_value and not finding.get("reveal"):
+        value = mask(
+            value, reveal_prefix=reveal_prefix, reveal_suffix=reveal_suffix
+        )
+    return value
+
+
+def format_xml(
+    findings,
+    root,
+    show_value=False,
+    truncated=False,
+    total_findings=None,
+    reveal_prefix=None,
+    reveal_suffix=None,
+):
+    """Render findings as a JUnit-style XML report.
+
+    Each finding becomes a failing ``testcase`` whose attributes carry every
+    finding field (path, line, severity, rule, rule_id, and the masked value)
+    plus a ``failure`` node with the description. Values are masked unless
+    show_value is set, matching format_json / format_csv.
+    """
+
+    ordered = sorted(findings, key=lambda f: (f["path"], f["line"], f["rule"]))
+    count = len(ordered)
+    suites = ET.Element(
+        "testsuites",
+        {
+            "name": "secret-guard",
+            "tests": str(count),
+            "failures": str(count),
+            "errors": "0",
+            "time": "0",
+        },
+    )
+    suite = ET.SubElement(
+        suites,
+        "testsuite",
+        {
+            "name": "secret-guard scan",
+            "tests": str(count),
+            "failures": str(count),
+            "errors": "0",
+            "skipped": "0",
+            "time": "0",
+        },
+    )
+    if truncated:
+        suite.set("truncated", "true")
+        suite.set("total_findings", str(total_findings))
+    for finding in ordered:
+        value = _masked_value(finding, show_value, reveal_prefix, reveal_suffix)
+        testcase = ET.SubElement(
+            suite,
+            "testcase",
+            {
+                "name": value,
+                "classname": "{}:{}".format(finding["path"], finding["line"]),
+                "time": "0",
+                "path": finding["path"],
+                "line": str(finding["line"]),
+                "severity": finding["severity"],
+                "rule": finding["rule"],
+                "rule_id": finding["rule_id"],
+            },
+        )
+        failure = ET.SubElement(
+            testcase,
+            "failure",
+            {"type": finding["severity"], "message": finding["description"]},
+        )
+        failure.text = value
+    header = '<?xml version="1.0" encoding="UTF-8"?>\n'
+    return header + ET.tostring(suites, encoding="unicode")
+
+
+def format_html(
+    findings,
+    root,
+    show_value=False,
+    truncated=False,
+    total_findings=None,
+    reveal_prefix=None,
+    reveal_suffix=None,
+):
+    """Render findings as a self-contained HTML report.
+
+    The output inlines every style so the report can be saved or emailed and
+    rendered anywhere. All finding fields are shown and values are masked
+    unless show_value is set.
+    """
+
+    ordered = sorted(findings, key=lambda f: (f["path"], f["line"], f["rule"]))
+    summary = summarize(findings)
+    count = len(ordered)
+
+    def esc(text):
+        return html.escape(str(text))
+
+    rows = []
+    for finding in ordered:
+        severity = finding["severity"]
+        rows.append(
+            "<tr>"
+            "<td>{path}</td>"
+            "<td>{line}</td>"
+            "<td class=\"sev-{sev}\">{sev}</td>"
+            "<td>{rule}</td>"
+            "<td>{rule_id}</td>"
+            "<td><code>{value}</code></td>"
+            "<td>{desc}</td>"
+            "</tr>".format(
+                path=esc(finding["path"]),
+                line=esc(finding["line"]),
+                sev=esc(severity),
+                rule=esc(finding["rule"]),
+                rule_id=esc(finding["rule_id"]),
+                value=esc(
+                    _masked_value(finding, show_value, reveal_prefix, reveal_suffix)
+                ),
+                desc=esc(finding["description"]),
+            )
+        )
+    truncation_note = ""
+    if truncated:
+        truncation_note = (
+            f"<p><strong>Note:</strong> showing {count} of "
+            f"{esc(total_findings)} findings "
+            f"({esc(total_findings - count)} truncated).</p>"
+        )
+    return (
+        "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n"
+        "<meta charset=\"utf-8\">\n"
+        "<title>secret-guard scan report</title>\n"
+        "<style>\n"
+        "body {{ font-family: -apple-system, Segoe UI, Roboto, "
+        "Helvetica, Arial, sans-serif; }}\n"
+        "table {{ border-collapse: collapse; width: 100%; }}\n"
+        "th, td {{ border: 1px solid #ddd; padding: 6px 10px; "
+        "text-align: left; }}\n"
+        "th {{ background: #f5f5f5; }}\n"
+        "code {{ background: #f5f5f5; padding: 1px 4px; border-radius: 3px; }}\n"
+        ".sev-critical {{ color: #b60205; font-weight: bold; }}\n"
+        ".sev-high {{ color: #d93f0b; }}\n"
+        ".sev-medium {{ color: #b08800; }}\n"
+        ".sev-low {{ color: #0969da; }}\n"
+        "</style>\n"
+        "</head>\n<body>\n"
+        "<h1>secret-guard scan report</h1>\n"
+        "<p>Scanned path: <code>{root}</code></p>\n"
+        "<p><strong>{total} finding(s):</strong> "
+        "{critical} critical, {high} high, {medium} medium, {low} low.</p>\n"
+        "{truncation_note}"
+        "<h2>Findings</h2>\n"
+        "<table>\n"
+        "<thead><tr><th>Path</th><th>Line</th><th>Severity</th><th>Rule</th>"
+        "<th>Rule ID</th><th>Value</th><th>Description</th></tr></thead>\n"
+        "<tbody>\n{rows}\n</tbody>\n</table>\n"
+        "</body>\n</html>\n"
+    ).format(
+        root=esc(root),
+        total=esc(summary["total"]),
+        critical=esc(summary["critical"]),
+        high=esc(summary["high"]),
+        medium=esc(summary["medium"]),
+        low=esc(summary["low"]),
+        truncation_note=truncation_note,
+        rows="\n".join(rows),
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+import xml.etree.ElementTree as ET
 from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
@@ -217,6 +218,56 @@ class CliTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             Path(tmp, "main.py").write_text("print('clean')\n", encoding="utf-8")
             result = self.run_cli(tmp, "scan", "--json", "--csv", ".")
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("not allowed with argument", result.stderr)
+
+    def test_scan_xml_emits_well_formed_output(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "secret.py").write_text(
+                f"TOKEN = '{SECRET}'", encoding="utf-8"
+            )
+            result = self.run_cli(tmp, "scan", "--xml", ".")
+            self.assertEqual(result.returncode, 1)
+            root = ET.fromstring(result.stdout)
+            self.assertEqual(root.tag, "testsuites")
+            self.assertGreaterEqual(len(root.findall(".//testcase")), 1)
+            self.assertNotIn(SECRET, result.stdout)
+
+    def test_scan_xml_show_value_exposes_full_value(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "secret.py").write_text(
+                f"TOKEN = '{SECRET}'", encoding="utf-8"
+            )
+            result = self.run_cli(tmp, "scan", "--xml", "--show-value", ".")
+            self.assertEqual(result.returncode, 1)
+            self.assertIn(SECRET, result.stdout)
+            ET.fromstring(result.stdout)
+
+    def test_scan_html_emits_report(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "secret.py").write_text(
+                f"TOKEN = '{SECRET}'", encoding="utf-8"
+            )
+            result = self.run_cli(tmp, "scan", "--html", ".")
+            self.assertEqual(result.returncode, 1)
+            self.assertTrue(result.stdout.lstrip().startswith("<!DOCTYPE html>"))
+            self.assertNotIn(SECRET, result.stdout)
+
+    def test_scan_format_flag_selects_format(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "main.py").write_text("print('clean')\n", encoding="utf-8")
+            xml = self.run_cli(tmp, "scan", "--format", "xml", ".")
+            self.assertEqual(xml.returncode, 0)
+            ET.fromstring(xml.stdout)
+            html = self.run_cli(tmp, "scan", "--format", "html", ".")
+            self.assertTrue(html.stdout.lstrip().startswith("<!DOCTYPE html>"))
+            text = self.run_cli(tmp, "scan", "--format", "text", ".")
+            self.assertIn("0 total", text.stdout)
+
+    def test_scan_format_and_flag_are_mutually_exclusive(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "main.py").write_text("print('clean')\n", encoding="utf-8")
+            result = self.run_cli(tmp, "scan", "--format", "xml", "--json", ".")
             self.assertNotEqual(result.returncode, 0)
             self.assertIn("not allowed with argument", result.stderr)
 

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -5,12 +5,15 @@ import io
 import json
 import re
 import unittest
+import xml.etree.ElementTree as ET
 
 from secretguard.reporter import (
     format_console,
     format_csv,
+    format_html,
     format_json,
     format_summary,
+    format_xml,
     mask,
     summarize,
 )
@@ -345,6 +348,96 @@ class FormatCsvTest(unittest.TestCase):
         data = rows[1:]
         self.assertEqual([(r[0], r[1]) for r in data],
                          [("a.py", "1"), ("a.py", "9"), ("b.py", "2")])
+
+
+class FormatXmlTest(unittest.TestCase):
+    def _parse(self, text):
+        root = ET.fromstring(text)
+        return root, root.findall(".//testcase")
+
+    def test_well_formed_and_header(self):
+        text = format_xml([], ".")
+        self.assertTrue(text.startswith('<?xml version="1.0" encoding="UTF-8"?>'))
+        root, cases = self._parse(text)
+        self.assertEqual(root.tag, "testsuites")
+        self.assertEqual(cases, [])
+
+    def test_one_testcase_per_finding(self):
+        _, cases = self._parse(format_xml([finding(), finding(severity="low")], "."))
+        self.assertEqual(len(cases), 2)
+
+    def test_all_fields_present(self):
+        f = finding(path="a.py", line=7, severity="high", rule="GitHub Token")
+        _, cases = self._parse(format_xml([f], ".", show_value=True))
+        tc = cases[0]
+        self.assertEqual(tc.get("path"), "a.py")
+        self.assertEqual(tc.get("line"), "7")
+        self.assertEqual(tc.get("severity"), "high")
+        self.assertEqual(tc.get("rule"), "GitHub Token")
+        self.assertEqual(tc.get("rule_id"), "github-token")
+        self.assertEqual(tc.get("name"), "ghp_secret")
+        failure = tc.find("failure")
+        self.assertEqual(failure.get("message"), "test")
+
+    def test_values_masked_by_default(self):
+        value = "ghp_secretvalue123"
+        _, cases = self._parse(format_xml([finding(value=value)], "."))
+        self.assertNotIn("secretvalue", cases[0].get("name"))
+
+    def test_full_values_printed_when_requested(self):
+        value = "ghp_secretvalue123"
+        _, cases = self._parse(format_xml([finding(value=value)], ".", show_value=True))
+        self.assertEqual(cases[0].get("name"), value)
+        self.assertEqual(cases[0].find("failure").text, value)
+
+    def test_counts_match_findings(self):
+        text = format_xml([finding(), finding(severity="medium")], ".")
+        root, _ = self._parse(text)
+        self.assertEqual(root.get("tests"), "2")
+        self.assertEqual(root.get("failures"), "2")
+
+    def test_truncated_reports_totals(self):
+        text = format_xml([finding()], ".", truncated=True, total_findings=5)
+        root, _ = self._parse(text)
+        self.assertEqual(root.find("testsuite").get("truncated"), "true")
+        self.assertEqual(root.find("testsuite").get("total_findings"), "5")
+
+
+class FormatHtmlTest(unittest.TestCase):
+    def test_document_and_summary_present(self):
+        text = format_html([], ".")
+        self.assertTrue(text.startswith("<!DOCTYPE html>"))
+        self.assertIn("<html", text)
+        self.assertIn("secret-guard scan report", text)
+        self.assertIn("<h1>secret-guard scan report</h1>", text)
+
+    def test_one_row_per_finding(self):
+        text = format_html([finding(), finding(severity="low")], ".", show_value=True)
+        self.assertEqual(text.count("<tr>"), 3)  # header + 2 findings
+
+    def test_all_fields_present(self):
+        f = finding(path="a.py", line=7, severity="high", rule="GitHub Token")
+        text = format_html([f], ".", show_value=True)
+        self.assertIn('sev-high', text)
+        self.assertIn("github-token", text)
+        self.assertIn(">a.py<", text)
+        self.assertIn(">7<", text)
+        self.assertIn("ghp_secret", text)
+
+    def test_values_masked_by_default(self):
+        value = "ghp_secretvalue123"
+        text = format_html([finding(value=value)], ".")
+        self.assertNotIn("secretvalue", text)
+
+    def test_full_values_printed_when_requested(self):
+        value = "ghp_secretvalue123"
+        text = format_html([finding(value=value)], ".", show_value=True)
+        self.assertIn(value, text)
+
+    def test_summary_counts_line(self):
+        findings = [finding(severity="critical"), finding(severity="low")]
+        text = format_html(findings, ".")
+        self.assertIn("1 critical, 0 high, 0 medium, 1 low", text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Addresses #54 — adds XML and HTML report output for CI/tooling that can't
parse the console report or JSON.

## Changes

- **`secretguard/reporter.py`** — two new formatters:
  - `format_xml()`: JUnit-style report; each finding is a failing `<testcase>`
    whose attributes carry every finding field (path, line, severity, rule,
    rule_id, value) plus a `<failure>` node with the description. Truncation
    is reported on the `<testsuite>` element. Values stay masked by default.
  - `format_html()`: self-contained HTML report (all CSS inlined) with a
    severity summary, a findings table (all fields), and a truncation note.
- **`secretguard/cli.py`** — new mutually-exclusive output options:
  - `--xml` / `--html` flags (parallel to `--json`/`--csv`/`--summary`)
  - `--format FMT` (`text | json | csv | summary | xml | html`) that also
    covers the existing flags as aliases; output routing factored into
    `_output_format()` / `_render_output()`.
- **Tests** — `FormatXmlTest` + `FormatHtmlTest` (well-formedness, all-fields
  present, masking, `--show-value`, counts, truncation) and CLI tests for
  `--xml`, `--html`, `--format`, and mutual exclusion with `--json`.
- **Docs** — README options list and `docs/cli.md` flags table updated.

## Acceptance criteria

- [x] XML and HTML output contain all finding fields.
- [x] No raw secret values without `--show-value`.
- [x] New tests assert masking and well-formedness.

## Checks

- `pytest` — 226 passed
- `ruff check` — all passed

Closes #54